### PR TITLE
List refresh and other stuff

### DIFF
--- a/frontend/App/Containers/ItemDetailScreen.js
+++ b/frontend/App/Containers/ItemDetailScreen.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
-import { ScrollView, Text, KeyboardAvoidingView } from 'react-native';
+import { View, Text, KeyboardAvoidingView } from 'react-native';
 import { connect } from 'react-redux';
+import { Header } from 'react-native-elements';
+
 // Add Actions - replace 'Your' with whatever your reducer is called :)
 // import YourActions from '../Redux/YourRedux'
 
@@ -10,11 +12,16 @@ import styles from './Styles/ItemDetailScreenStyle';
 class ItemDetailScreen extends Component {
   render () {
     return (
-      <ScrollView style={styles.container}>
+      <View style={styles.container}>
+        <Header
+          leftComponent={{ icon: 'menu', color: '#fff' }}
+          centerComponent={{ text: 'Item Details', style: { color: '#fff' } }}
+          rightComponent={{ icon: 'home', color: '#fff' }}
+        />
         <KeyboardAvoidingView behavior='position'>
           <Text>ItemDetailScreen</Text>
         </KeyboardAvoidingView>
-      </ScrollView>
+      </View>
     )
   }
 }

--- a/frontend/App/Containers/ItemList.tsx
+++ b/frontend/App/Containers/ItemList.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { SectionList, Text, TouchableHighlight, View } from 'react-native';
 import Search from 'react-native-search-box';
-import Swipeout from 'react-native-swipeout';
-import Icon from 'react-native-vector-icons/dist/FontAwesome';
+import { Card, ListItem, Icon, Header } from 'react-native-elements';
 import { connect, Dispatch } from 'react-redux';
-
+import { Navigation } from 'react-native-navigation';
 import UserActions from '../Redux/UserRedux';
 import styles from './Styles/ItemListStyle';
 
@@ -23,14 +22,14 @@ class ItemList extends React.PureComponent  {
       {
         key: 'Movies',
         data: [
-          {title: 'The Fate of the Furious', platform: 'iTunes'},
-          {title: 'Patti Cake$$$$$', platform: 'HBO'}
+          {title: 'The Fate of the Furious', platform: 'iTunes', type: 'movie'},
+          {title: 'Patti Cake$$$$$', platform: 'HBO', type: 'movie'}
         ]
       }, {
         key: 'TV',
         data: [
-          {title: 'Halt & Catch Fire', platform: 'Netflix'},
-          {title: 'Hamilton\'s Pharmacopeia', platform: 'Vice'}
+          {title: 'Halt & Catch Fire', platform: 'Netflix', type: 'tv'},
+          {title: 'Hamilton\'s Pharmacopeia', platform: 'Vice', type: 'tv'}
         ]
       }
     ]
@@ -55,26 +54,28 @@ class ItemList extends React.PureComponent  {
   *
   * Note: You can remove section/separator functions and jam them in here
   *************************************************************/
-  renderItem ({section, item}) {
-    const deleteIcon = <Icon name="trash-o" size={20} color="#fff" />;
-    let swipeoutBtns = [
-      {
-        text: deleteIcon
+  goToItemDetail() {
+    Navigation.push(this.props.componentId, {
+      component: {
+        name: 'navigation.main.ItemDetailScreen',
+        options: {
+          topBar: {
+            visible: false
+          }
+        }
       }
-    ];
+    })
+  }
 
+  renderItem ({section, item}) {
     return (
-      <Swipeout right={swipeoutBtns} 
-        autoClose={true} backgroundColor= 'transparent'>
-        <TouchableHighlight
-          onPress={() => this.props.navigation.navigate('ItemDetailScreen')} 
-        >
-        <View style={styles.row} >
-          <Text style={styles.boldLabel}>{item.title}</Text>
-          <Text style={styles.label}>{item.platform}</Text>
-        </View>
-      </TouchableHighlight>
-      </Swipeout>
+        <ListItem 
+          key={this.keyExtractor}
+          title={item.title}
+          leftIcon={{name: item.type}}
+          subtitle={item.platform}
+          onPress={this.goToItemDetail.bind(this)} 
+        />
     )
   }
 
@@ -146,29 +147,38 @@ class ItemList extends React.PureComponent  {
   // e.g. itemLayout={(data, index) => (
   //   {length: ITEM_HEIGHT, offset: ITEM_HEIGHT * index, index}
   // )}
-
+  
   render () {
     return (
       <View style={styles.container}>
+      <Header
+        leftComponent={{ icon: 'menu', color: '#fff' }}
+        centerComponent={{ text: 'My List', style: { color: '#fff' } }}
+        rightComponent={{ icon: 'home', color: '#fff' }}
+      />
        <Search
           ref="search_box"
+          backgroundColor='white'
+          style={{flex:1}}
           /**
           * There are many props options:
           * https://github.com/agiletechvn/react-native-search-box
           */
         />
-        <Text style={{color: 'white'}}>{this.props.user && this.props.user.name ? this.props.user.name : 'Fetching...'}</Text>
-        <SectionList
-          renderSectionHeader={this.renderSectionHeader}
-          sections={this.state.data}
-          contentContainerStyle={styles.listContent}
-          data={this.state.dataObjects}
-          renderItem={this.renderItem.bind(this)}
-          keyExtractor={this.keyExtractor}
-          initialNumToRender={this.oneScreensWorth}
-          ListHeaderComponent={this.renderHeader}
-          ListEmptyComponent={this.renderEmpty}
-        />
+        <Text style={styles.username}>{this.props.user && this.props.user.name ? this.props.user.name : 'Fetching...'}</Text>
+        <Card>
+          <SectionList
+            renderSectionHeader={this.renderSectionHeader}
+            sections={this.state.data}
+            contentContainerStyle={styles.listContent}
+            data={this.state.dataObjects}
+            renderItem={this.renderItem.bind(this)}
+            keyExtractor={this.keyExtractor}
+            initialNumToRender={this.oneScreensWorth}
+            ListHeaderComponent={this.renderHeader}
+            ListEmptyComponent={this.renderEmpty}
+          />
+        </Card>
       </View>
     )
   }

--- a/frontend/App/Containers/Styles/ItemListStyle.js
+++ b/frontend/App/Containers/Styles/ItemListStyle.js
@@ -4,8 +4,7 @@ import { ApplicationStyles, Metrics, Colors } from '../../Themes';
 export default StyleSheet.create({
   ...ApplicationStyles.screen,
   container: {
-    flex: 1,
-    backgroundColor: Colors.background
+    flex: 1
   },
   row: {
     flex: 1,
@@ -13,18 +12,24 @@ export default StyleSheet.create({
     marginVertical: Metrics.smallMargin,
     justifyContent: 'center'
   },
+  search: {
+    backgroundColor: Colors.snow
+  },
   boldLabel: {
     fontWeight: 'bold',
     alignSelf: 'center',
-    color: Colors.snow,
+    color: Colors.charcoal,
     textAlign: 'center',
     marginBottom: Metrics.smallMargin
   },
   label: {
     textAlign: 'center',
-    color: Colors.snow
+    color: Colors.charcoal
   },
   listContent: {
     marginTop: Metrics.baseMargin
+  },
+  username: {
+    color: Colors.charcoal
   }
 });

--- a/frontend/App/Navigation/AppNavigation.tsx
+++ b/frontend/App/Navigation/AppNavigation.tsx
@@ -6,6 +6,7 @@ import { Store } from 'redux';
 import LoginScreen from '../Containers/LoginScreen';
 import SignupScreen from '../Containers/SignupScreen';
 import ItemList from '../Containers/ItemList';
+import ItemDetailScreen from '../Containers/ItemDetailScreen';
 
 function sceneCreator(Scene: React.Component, store: Store<{}>) {
   return () => {
@@ -42,6 +43,7 @@ export default function startNav(store: Store<{}>) {
   Navigation.registerComponent('navigation.main.SignupScreen', sceneCreator(SignupScreen, store));
 
   Navigation.registerComponent('navigation.main.ListView', sceneCreator(ItemList, store));
+  Navigation.registerComponent('navigation.main.ItemDetailScreen', sceneCreator(ItemDetailScreen, store));
   
   Navigation.events().registerAppLaunchedListener(() => {
     Navigation.setRoot({
@@ -51,7 +53,7 @@ export default function startNav(store: Store<{}>) {
           children: [
             {
               component: {
-                name: 'navigation.main.LoginScreen',
+                name: 'navigation.main.ListView',
                 options: {
                   topBar: {
                     visible: false


### PR DESCRIPTION
Refresh of the itemList:
![image](https://user-images.githubusercontent.com/6005331/41495301-d8d477de-70f1-11e8-956e-6dc34c8acef1.png)

Added Header Menu.  Thinking this can be used as a logged in header.  Menu could include stuff like 'logout' or 'settings'.

Temporarily removed Swipeout, which is used to show a menu when you slide an individual item.  Was having a few issues, we can revisit when we start talking about deleting items from a list.