### PR TITLE
Ga improvements

### DIFF
--- a/frontend/App/Components/Analytics.tsx
+++ b/frontend/App/Components/Analytics.tsx
@@ -1,3 +1,5 @@
 import { GoogleAnalyticsTracker } from 'react-native-google-analytics-bridge';
+import { version } from '../../package.json';
 
 export const tracker = new GoogleAnalyticsTracker('UA-123012032-1');
+export const appVersion = `v${version}`;

--- a/frontend/App/Containers/ItemDetailScreen.tsx
+++ b/frontend/App/Containers/ItemDetailScreen.tsx
@@ -15,7 +15,7 @@ import UserActions from '../Redux/UserRedux';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { teletrackerApi } from '../Sagas';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 import headerStyles from '../Themes/ApplicationStyles';
 import styles from './Styles/ItemDetailScreenStyle';
@@ -87,7 +87,9 @@ class ItemDetailScreen extends Component<Props, State> {
 
     addItem() {
         // Track when users add an item on the item details screen
-        tracker.trackEvent('item-detail-action', 'add-item');
+        tracker.trackEvent('item-detail-action', 'add-item', {
+            label: appVersion
+        });
 
         this.props.addItemToList(this.props.componentId, 'default', this.state.item.id);
 
@@ -98,7 +100,9 @@ class ItemDetailScreen extends Component<Props, State> {
 
     markAsWatched() {
         // Track when users mark item watched on the item details screen
-        tracker.trackEvent('item-detail-action', 'mark-as-watched');
+        tracker.trackEvent('item-detail-action', 'mark-as-watched', {
+            label: appVersion
+        } );
 
         this.props.markAsWatched(this.props.componentId, this.state.item.id, this.state.item.type);
     }

--- a/frontend/App/Containers/LoginScreen.tsx
+++ b/frontend/App/Containers/LoginScreen.tsx
@@ -11,7 +11,7 @@ import Logo from '../Components/Logo';
 import UserActions, { SignupState } from '../Redux/UserRedux'
 import styles from './Styles/LoginScreenStyle';
 import { Navigation } from 'react-native-navigation';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 class LoginScreen extends Component {
     static get options() {
@@ -29,6 +29,9 @@ class LoginScreen extends Component {
     }
 
     goToSignup() {
+        tracker.trackEvent('login-action', 'signup', {
+            label: appVersion
+        });
         Navigation.push(this.props.componentId, {
         component: {
             name: 'navigation.main.SignupScreen',

--- a/frontend/App/Containers/SearchScreen.tsx
+++ b/frontend/App/Containers/SearchScreen.tsx
@@ -23,7 +23,7 @@ import ListActions from '../Redux/ListRedux';
 import SearchActions from '../Redux/SearchRedux';
 import ReduxState from '../Redux/State';
 import UserActions, { UserState } from '../Redux/UserRedux';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 import { Colors } from './../Themes/'; //testing only, cleanup later
 import styles from './Styles/SearchScreenStyle';
@@ -110,7 +110,9 @@ class SearchScreen extends Component<Props, State> {
 
     executeSearch() {
         // Track when users add items from search screen
-        tracker.trackEvent('search-action', 'search');
+        tracker.trackEvent('search-action', 'search', {
+            label: appVersion
+        });
 
         this.props.doSearch(this.state.searchText);
     }
@@ -123,7 +125,9 @@ class SearchScreen extends Component<Props, State> {
     onCancel = () => {
         return new Promise((resolve, reject) => {
             // Track when users cancel search
-            tracker.trackEvent('search-action', 'cancel');
+            tracker.trackEvent('search-action', 'cancel', {
+                label: appVersion
+            });
 
             this.props.clearSearch(this.state.searchText);
             resolve();
@@ -132,7 +136,9 @@ class SearchScreen extends Component<Props, State> {
 
     addItem(itemId) {
         // Track when users add items from search screen
-        tracker.trackEvent('search-action', 'add-item');
+        tracker.trackEvent('search-action', 'add-item', {
+            label: appVersion
+        });
 
         this.props.addItemToList(this.props.componentId, 'default', itemId);
     }
@@ -192,7 +198,9 @@ class SearchScreen extends Component<Props, State> {
 
     goToItemDetail(item: object) {
         // Track when users navigate to an item from search screen
-        tracker.trackEvent('search-action', 'view-item-details');
+        tracker.trackEvent('search-action', 'view-item-details', {
+            label: appVersion
+        });
 
         const view = R.mergeDeepLeft(NavigationConfig.DetailView, {
             component: {

--- a/frontend/App/Containers/SignupScreen.tsx
+++ b/frontend/App/Containers/SignupScreen.tsx
@@ -6,7 +6,7 @@ import UserActions, { SignupState } from '../Redux/UserRedux'
 import { State as AppState } from '../Redux/State';
 import { Card, Button, FormLabel, FormInput } from "react-native-elements";
 import Logo from '../Components/Logo';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 // Styles
 import styles from './Styles/SignupScreenStyle';
@@ -36,6 +36,9 @@ class SignupScreen extends Component<Props, State> {
     }
 
     goToLogin() {
+        tracker.trackEvent('signup-action', 'login', {
+            label: appVersion
+        });
         Navigation.pop(this.props.componentId, {});
     }
 

--- a/frontend/App/Sagas/EventsSagas.ts
+++ b/frontend/App/Sagas/EventsSagas.ts
@@ -3,14 +3,17 @@ import { call, put } from 'redux-saga/effects';
 
 import EventsActions from '../Redux/EventsRedux';
 import { TeletrackerApi } from '../Services/TeletrackerApi';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 export function * retrieveEvents(api: TeletrackerApi) {
     let response: ApiResponse<any> = yield call([api, api.getEvents]);
 
     if (response.ok) {
         // Track API response duration
-        tracker.trackTiming('api', response.duration, { name: 'retrieveEvents' });
+        tracker.trackTiming('api', response.duration, {
+            name: 'retrieveEvents',
+            label: appVersion
+        });
         yield put(EventsActions.retrieveEventsSuccess(response.data));
     } else {
         // Track failed search in GA

--- a/frontend/App/Sagas/ListSagas.ts
+++ b/frontend/App/Sagas/ListSagas.ts
@@ -5,14 +5,17 @@ import { all, call, put } from 'redux-saga/effects';
 import ListActions from '../Redux/ListRedux';
 import UserActions from '../Redux/UserRedux';
 import { TeletrackerApi } from '../Services/TeletrackerApi';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 export function* addToList(api: TeletrackerApi, { componentId, listId, itemId }: AnyAction) {
     const response: ApiResponse<any> = yield call([api, api.addItemToList], listId, itemId);
 
     if (response.ok) {
         // Track API response duration
-        tracker.trackTiming('api', response.duration, { name: 'addToList' });
+        tracker.trackTiming('api', response.duration, {
+            name: 'addToList',
+            label: appVersion
+        });
         yield all([
             put(UserActions.userRequest(componentId)),
             put(ListActions.addToListSuccess(response.data))

--- a/frontend/App/Sagas/SearchSagas.ts
+++ b/frontend/App/Sagas/SearchSagas.ts
@@ -4,14 +4,17 @@ import { call, put } from 'redux-saga/effects';
 
 import SearchActions from '../Redux/SearchRedux';
 import { TeletrackerApi } from '../Services/TeletrackerApi';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 export function * search(api: TeletrackerApi, { searchText }: AnyAction) {
     const response: ApiResponse<any> = yield call([api, api.search], searchText);
 
     if (response.ok) {
         // Track API response duration
-        tracker.trackTiming('api', response.duration, { name: 'search' });
+        tracker.trackTiming('api', response.duration, {
+            name: 'search',
+            label: appVersion
+        });
         yield put(SearchActions.searchSuccess(response.data));
     } else {
         // Track failed search in GA

--- a/frontend/App/Sagas/UserSagas.ts
+++ b/frontend/App/Sagas/UserSagas.ts
@@ -7,7 +7,7 @@ import UserActions from '../Redux/UserRedux';
 import { TeletrackerApi } from '../Services/TeletrackerApi';
 import { AnyAction } from 'redux';
 import * as NavigationConfig from '../Navigation/NavigationConfig';
-import { tracker } from '../Components/Analytics';
+import { tracker, appVersion } from '../Components/Analytics';
 
 const getListViewNavEffect = (componentId: string) => {
     return call([Navigation, Navigation.setStackRoot], componentId, NavigationConfig.ListBottomTabs);
@@ -22,7 +22,10 @@ export function* getUser(api: TeletrackerApi, { componentId }: AnyAction) {
 
     if (response.ok) {
         // Track API response duration
-        tracker.trackTiming('api', response.duration, { name: 'getUser' });
+        tracker.trackTiming('api', response.duration, { 
+            name: 'getUser',
+            label: appVersion
+        });
         yield put(UserActions.userSuccess(response.data));
     } else {
         tracker.trackException(response.problem, false);
@@ -39,7 +42,10 @@ export function * loginUser(api: TeletrackerApi, action: AnyAction) {
 
     if (response.ok) {
         // Track successful logins in GA
-        tracker.trackTiming('api', response.duration, { name: 'loginUser' });
+        tracker.trackTiming('api', response.duration, {
+            name: 'loginUser',
+            label: appVersion
+        });
         tracker.setUser(response.data.data.userId.toString());
         tracker.trackEvent('user', 'login');
 
@@ -61,7 +67,10 @@ export function * logoutUser(api: TeletrackerApi, {componentId}: AnyAction) {
 
     if (response.ok) {
         // Track logout success in GA
-        tracker.trackTiming('api', response.duration, { name: 'logoutUser' });
+        tracker.trackTiming('api', response.duration, {
+            name: 'logoutUser',
+            label: appVersion
+        });
         tracker.trackEvent('user', 'logout');
 
         yield all([
@@ -82,7 +91,10 @@ export function * signupUser(api: TeletrackerApi, action: any) {
 
     if (response.ok) {
         // Track successful signups in GA
-        tracker.trackTiming('api', response.duration, { name: 'signupUser' });
+        tracker.trackTiming('api', response.duration, {
+            name: 'signupUser',
+            label: appVersion
+        });
         tracker.setUser(response.data.data.userId.toString());
         tracker.trackEvent('user', 'signup');
 


### PR DESCRIPTION
- Enabled user ID tracking so we get improved metrics around users.  Also, in the future if we ever had a webapp this would allow us to consolidate engagement by users across devices.
- Export the TT version and pass it into the GA events so we can isolate when we have improvements or degraded performance by a specific app version.
- Pass in all api response times into GA to track api performance.