### PR TITLE
More search Stuff

### DIFF
--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -218,7 +218,6 @@ interface ItemCardState {
   currentId: string;
   currentType: string;
   imageLoaded: boolean;
-  imageURL: string;
 }
 
 type Props = ItemCardProps & DispatchProps & WithUserProps;
@@ -241,7 +240,6 @@ class ItemCard extends Component<Props, ItemCardState> {
     currentId: '',
     currentType: '',
     imageLoaded: false,
-    imageURL: '',
   };
 
   constructor(props: Props) {
@@ -262,33 +260,22 @@ class ItemCard extends Component<Props, ItemCardState> {
     this.setState({
       currentId: itemId,
     });
-
-    let poster = getPosterPath(item);
-    let image = new Image();
-    image.src = 'https://image.tmdb.org/t/p/w300' + poster;
-    this.setState({
-      imageURL: image.src,
-    });
-    image.onload = this.handleImageLoaded;
-    image.onerror = this.handleImageError;
   }
 
-  handleImageLoaded = () => {
-    this.setState({ imageLoaded: true });
+  handleListsModalOpen = (item: Thing) => {
+    this.setState({ listsModalOpen: true });
   };
 
-  handleImageError = () => {
-    this.setState({ imageLoaded: false });
+  handleListsModalClose = () => {
+    this.setState({ listsModalOpen: false });
   };
 
-  handleListsModal = () => {
-    this.setState({ listsModalOpen: !this.state.listsModalOpen });
+  handleDeleteModalOpen = () => {
+    this.setState({ deleteConfirmationOpen: true });
   };
 
-  handleDeleteModal = () => {
-    this.setState({
-      deleteConfirmationOpen: !this.state.deleteConfirmationOpen,
-    });
+  handleDeleteModalClose = () => {
+    this.setState({ deleteConfirmationOpen: false });
   };
 
   handleHoverEnter = () => {
@@ -299,8 +286,12 @@ class ItemCard extends Component<Props, ItemCardState> {
     this.setState({ isHovering: false });
   };
 
-  handleHoverRating = () => {
-    this.setState({ hoverRating: !this.state.hoverRating });
+  handleHoverRatingOpen = () => {
+    this.setState({ hoverRating: true });
+  };
+
+  handleHoverRatingClose = () => {
+    this.setState({ hoverRating: false });
   };
 
   handleRemoveFromList = () => {
@@ -310,7 +301,7 @@ class ItemCard extends Component<Props, ItemCardState> {
       removeFromLists: [this.props.listContext!.id.toString()],
     });
     this.setState({ deleted: true });
-    this.handleDeleteModal();
+    this.handleDeleteModalClose();
   };
 
   toggleItemWatched = () => {
@@ -324,7 +315,7 @@ class ItemCard extends Component<Props, ItemCardState> {
     } else {
       this.props.updateUserItemTags(payload);
       this.setState({ hoverRating: true });
-      this.handleHoverRating();
+      this.handleHoverRatingOpen();
     }
   };
 
@@ -381,7 +372,7 @@ class ItemCard extends Component<Props, ItemCardState> {
       return makeLink(
         <CardMedia
           className={this.props.classes.cardMedia}
-          image={this.state.imageURL}
+          image={'https://image.tmdb.org/t/p/w300' + poster}
           title={thing.name}
         />,
       );
@@ -406,7 +397,7 @@ class ItemCard extends Component<Props, ItemCardState> {
     return (
       <Dialog
         open={deleteConfirmationOpen}
-        onClose={this.handleDeleteModal}
+        onClose={this.handleDeleteModalClose}
         aria-labelledby="alert-dialog-title"
         aria-describedby="alert-dialog-description"
       >
@@ -417,7 +408,7 @@ class ItemCard extends Component<Props, ItemCardState> {
           </DialogContentText>
         </DialogContent>
         <DialogActions>
-          <Button onClick={this.handleDeleteModal} color="primary">
+          <Button onClick={this.handleDeleteModalClose} color="primary">
             Cancel
           </Button>
           <Button onClick={this.handleRemoveFromList} color="primary" autoFocus>
@@ -479,7 +470,7 @@ class ItemCard extends Component<Props, ItemCardState> {
               <Tooltip title="Manage Lists" placement={tooltipPlacement}>
                 <IconButton
                   aria-label="Manage Lists"
-                  onClick={() => this.handleListsModal()}
+                  onClick={() => this.handleListsModalOpen(item)}
                   disableRipple
                 >
                   <PlaylistAdd className={classes.hoverWatch} />
@@ -501,7 +492,7 @@ class ItemCard extends Component<Props, ItemCardState> {
               <Tooltip title={'Rate it!'} placement={tooltipPlacement}>
                 <IconButton
                   aria-label="Rate it!"
-                  onClick={this.handleHoverRating}
+                  onClick={this.handleHoverRatingOpen}
                 >
                   {this.itemHasTag(ACTION_ENJOYED) ? (
                     <ThumbUp className={classes.hoverRatingThumbsUp} />
@@ -527,7 +518,7 @@ class ItemCard extends Component<Props, ItemCardState> {
                 <IconButton
                   aria-label="Delete"
                   className={classes.hoverDelete}
-                  onClick={this.handleDeleteModal}
+                  onClick={this.handleDeleteModalOpen}
                   disableRipple
                 >
                   <DeleteIcon />


### PR DESCRIPTION
- Make caret color white on devices that support caret color.  Right now it was appearing as blue on iOS devices/Chrome but white on desktop/chrome.  This should fix that.
- Use `type=search` which will use the users search keyboard for mobile
- Hide default "X" that appears for search input, going to use my custom solution for now because it likely has more browser support. 