### PR TITLE
People detail page

### DIFF
--- a/web/src/components/ItemCard.tsx
+++ b/web/src/components/ItemCard.tsx
@@ -343,7 +343,7 @@ class ItemCard extends Component<Props, ItemCardState> {
   renderPoster = (thing: Thing) => {
     let { classes } = this.props;
     let { isHovering, hoverRating } = this.state;
-    console.log(thing);
+
     return (
       <div
         className={isHovering ? classes.cardHoverEnter : classes.cardHoverExit}

--- a/web/src/containers/ItemDetail.tsx
+++ b/web/src/containers/ItemDetail.tsx
@@ -378,7 +378,7 @@ class ItemDetails extends Component<Props, State> {
     if (!itemDetail) {
       return this.renderLoading();
     }
-    console.log(itemDetail);
+
     return isFetching || !itemDetail ? (
       this.renderLoading()
     ) : (


### PR DESCRIPTION
V1 of People Detail Page.  Currently displaying genre ID, instead of name because API is not returning genre name. 

Screenshot:
![image](https://user-images.githubusercontent.com/6005331/64130206-ca9f5300-cd8e-11e9-9856-69e11628168b.png)

Genre filters are an aggregation of all genres from a persons collective work.  Clicking on one will filter their filmography down to only content in the specified genre.

Sorting will sort the filter based on popularity (default), Latest, or Oldest.

Current requires two backend changes (to my knowledge):
- Return genre name within the `combined_credits` payload
- Return the normalized name & name in that same payload.  This allows us to generate the URLs via ItemCard for items.

