### PR TITLE
Thing as class WIP

### DIFF
--- a/web/src/actions/item-detail/get_item_details.ts
+++ b/web/src/actions/item-detail/get_item_details.ts
@@ -1,7 +1,7 @@
 import { put, takeEvery } from '@redux-saga/core/effects';
 import { clientEffect, createAction } from '../utils';
 import { ErrorFluxStandardAction, FSA } from 'flux-standard-action';
-import { Thing } from '../../types';
+import { ApiThing } from '../../types/Thing';
 
 export const ITEM_FETCH_INITIATED = 'item-detail/INITIATED';
 export const ITEM_FETCH_SUCCESSFUL = 'item-detail/SUCCESSFUL';
@@ -19,7 +19,7 @@ export type ItemFetchInitiatedAction = FSA<
 
 export type ItemFetchSuccessfulAction = FSA<
   typeof ITEM_FETCH_SUCCESSFUL,
-  Thing
+  ApiThing
 >;
 
 export type ItemFetchFailedAction = ErrorFluxStandardAction<

--- a/web/src/actions/people/get_person.ts
+++ b/web/src/actions/people/get_person.ts
@@ -1,7 +1,7 @@
 import { ErrorFluxStandardAction, FSA } from 'flux-standard-action';
-import { Person } from '../../types';
 import { clientEffect, createAction } from '../utils';
 import { put, takeEvery } from '@redux-saga/core/effects';
+import Person, { PersonFactory } from '../../types/Person';
 
 export const PERSON_FETCH_INITIATED = 'person/fetch/INITIATED';
 export const PERSON_FETCH_SUCCESSFUL = 'person/fetch/SUCCESSFUL';
@@ -46,7 +46,7 @@ export const fetchPersonDetailsSaga = function*() {
       let response = yield clientEffect(client => client.getPerson, payload.id);
 
       if (response.ok) {
-        yield put(personFetchSuccess(response.data.data));
+        yield put(personFetchSuccess(PersonFactory.create(response.data.data)));
       } else {
         yield put(personFetchFailed(new Error()));
       }

--- a/web/src/actions/popular/popular.ts
+++ b/web/src/actions/popular/popular.ts
@@ -2,7 +2,7 @@ import { put, takeEvery } from '@redux-saga/core/effects';
 import { clientEffect, createAction, createBasicAction } from '../utils';
 import { defaultMovieMeta } from '../lists';
 import { ErrorFSA, FSA } from 'flux-standard-action';
-import { Thing } from '../../types';
+import Thing, { ThingFactory } from '../../types/Thing';
 
 export const POPULAR_INITIATED = 'popular/INITIATED';
 export const POPULAR_SUCCESSFUL = 'popular/SUCCESSFUL';
@@ -44,7 +44,11 @@ export const popularSaga = function*() {
       );
 
       if (response.ok) {
-        yield put(popularSuccess({ popular: response.data.data }));
+        yield put(
+          popularSuccess({
+            popular: response.data.data.map(ThingFactory.create),
+          }),
+        );
       }
     } catch (e) {
       console.error(e);

--- a/web/src/components/AddToListDialog.tsx
+++ b/web/src/components/AddToListDialog.tsx
@@ -33,13 +33,14 @@ import {
 } from '../actions/lists';
 import { AppState } from '../reducers';
 import { ListOperationState, ListsByIdMap } from '../reducers/lists';
-import { List, Thing } from '../types';
+import { List } from '../types';
 import _ from 'lodash';
 import { UserSelf } from '../reducers/user';
 import { Cancel, Check, PlaylistAdd } from '@material-ui/icons';
 import CreateAListValidator, {
   CreateAListValidationStateObj,
 } from '../utils/validation/CreateAListValidator';
+import Thing, { ThingLikeStruct } from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -65,7 +66,7 @@ interface AddToListDialogProps {
   open: boolean;
   onClose: () => void;
   userSelf: UserSelf;
-  item: Thing;
+  item: ThingLikeStruct;
   listOperations: ListOperationState;
   listItemAddLoading: boolean;
   createAListLoading: boolean;
@@ -164,7 +165,7 @@ class AddToListDialog extends Component<Props, AddToListDialogState> {
     });
   };
 
-  listContainsItem = (list: List, item: Thing) => {
+  listContainsItem = (list: List, item: ThingLikeStruct) => {
     return list.things ? R.any(R.propEq('id', item.id), list.things) : false;
   };
 

--- a/web/src/components/Availability.tsx
+++ b/web/src/components/Availability.tsx
@@ -18,8 +18,9 @@ import {
   Theaters,
 } from '@material-ui/icons';
 import * as R from 'ramda';
-import { Availability, Network, Thing } from '../types';
+import { Availability, Network } from '../types';
 import React, { Component } from 'react';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({

--- a/web/src/components/Cast.tsx
+++ b/web/src/components/Cast.tsx
@@ -7,7 +7,7 @@ import {
   WithStyles,
   withStyles,
 } from '@material-ui/core';
-import { CastMember, Thing } from '../types';
+import { CastMember } from '../types';
 import React, { Component } from 'react';
 import { getMetadataPath } from '../utils/metadata-access';
 import { parseInitials } from '../utils/textHelper';
@@ -15,6 +15,7 @@ import RouterLink from './RouterLink';
 import * as R from 'ramda';
 import _ from 'lodash';
 import { Person } from 'themoviedb-client-typed';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -58,7 +59,7 @@ interface OwnProps {
 
 type Props = OwnProps & WithStyles<typeof styles>;
 
-class ThingAvailability extends Component<Props, {}> {
+class Cast extends Component<Props, {}> {
   constructor(props: Props) {
     super(props);
   }
@@ -137,4 +138,4 @@ class ThingAvailability extends Component<Props, {}> {
   }
 }
 
-export default withStyles(styles)(ThingAvailability);
+export default withStyles(styles)(Cast);

--- a/web/src/components/Recommendations.tsx
+++ b/web/src/components/Recommendations.tsx
@@ -6,12 +6,11 @@ import {
   WithStyles,
   withStyles,
 } from '@material-ui/core';
-import { Thing } from '../types';
 import React, { Component } from 'react';
 import { getMetadataPath } from '../utils/metadata-access';
-import _ from 'lodash';
 import ItemCard from './ItemCard';
 import { UserSelf } from '../reducers/user';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({

--- a/web/src/components/ResponsiveImage.tsx
+++ b/web/src/components/ResponsiveImage.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { Icon } from '@material-ui/core';
-import { getMetadataPath } from '../utils/metadata-access';
-import { Thing } from '../types';
 import imagePlaceholder from '../assets/images/imagePlaceholder.png';
+import HasImagery from '../types/HasImagery';
 
 interface imgProps {
-  item: Thing;
+  item: HasImagery;
   imageType: 'poster' | 'backdrop' | 'profile';
   imageStyle?: object;
   pictureStyle?: object;
@@ -37,8 +36,19 @@ export const ResponsiveImage: React.FC<imgProps> = ({
     return sourceSet.join(',');
   }
 
-  let imageName =
-    getMetadataPath(item, `${imageType}_path`) || item[`${imageType}_path`];
+  let imageName;
+  switch (imageType) {
+    case 'backdrop':
+      imageName = item.backdropPath;
+      break;
+    case 'poster':
+      imageName = item.posterPath;
+      break;
+    case 'profile':
+      imageName = item.profilePath;
+      break;
+  }
+
   const baseImageURL = 'https://image.tmdb.org/t/p/';
   /* TODO: Figure out image/webp story and add here */
   const posterSpecs = [

--- a/web/src/containers/Home.tsx
+++ b/web/src/containers/Home.tsx
@@ -16,8 +16,8 @@ import ItemCard from '../components/ItemCard';
 import withUser, { WithUserProps } from '../components/withUser';
 import { AppState } from '../reducers';
 import { layoutStyles } from '../styles';
-import { Thing } from '../types';
 import { Error as ErrorIcon } from '@material-ui/icons';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -130,7 +130,7 @@ const mapStateToProps = (appState: AppState) => {
     isSearching: appState.search.searching,
     // TODO: Pass SearchResult object that either contains error or a response
     error: appState.search.error,
-    searchResults: R.path<Thing[]>(['search', 'results', 'data'], appState),
+    searchResults: appState.search.results,
   };
 };
 

--- a/web/src/containers/ItemDetail.tsx
+++ b/web/src/containers/ItemDetail.tsx
@@ -36,7 +36,7 @@ import {
 import withUser, { WithUserProps } from '../components/withUser';
 import { AppState } from '../reducers';
 import { layoutStyles } from '../styles';
-import { ActionType, Thing } from '../types';
+import { ActionType } from '../types';
 import { getMetadataPath } from '../utils/metadata-access';
 import { ResponsiveImage } from '../components/ResponsiveImage';
 import ThingAvailability from '../components/Availability';
@@ -45,6 +45,7 @@ import Recommendations from '../components/Recommendations';
 import imagePlaceholder from '../assets/images/imagePlaceholder.png';
 import AddToListDialog from '../components/AddToListDialog';
 import { formatRuntime } from '../utils/textHelper';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -243,10 +244,8 @@ class ItemDetails extends Component<Props, State> {
   };
 
   itemMarkedAsWatched = () => {
-    if (this.props.itemDetail && this.props.itemDetail.userMetadata) {
-      return R.any(tag => {
-        return tag.action == ActionType.Watched;
-      }, this.props.itemDetail.userMetadata.tags);
+    if (this.props.itemDetail) {
+      return this.props.itemDetail.itemMarkedAsWatched;
     }
 
     return false;
@@ -261,16 +260,11 @@ class ItemDetails extends Component<Props, State> {
   };
 
   renderTitle = (thing: Thing) => {
-    const title =
-      (thing.type === 'movie'
-        ? getMetadataPath(thing, 'title')
-        : getMetadataPath(thing, 'name')) || '';
+    const title = thing.name;
     const voteAverage = Number(getMetadataPath(thing, 'vote_average')) || 0;
     const voteCount = Number(getMetadataPath(thing, 'vote_count')) || 0;
-    const runtime =
-      thing.type === 'movie'
-        ? formatRuntime(getMetadataPath(thing, 'runtime'), thing.type)
-        : formatRuntime(getMetadataPath(thing, 'episode_run_time'), thing.type);
+    // TODO: handle undefined runtime
+    const runtime = formatRuntime(thing.runtime || 0, thing.type);
 
     return (
       <div
@@ -551,7 +545,7 @@ class ItemDetails extends Component<Props, State> {
 }
 
 const findThingBySlug = (things: Thing[], slug: string) => {
-  return R.find(t => t.normalizedName === slug, things);
+  return R.find(t => t.slug === slug, things);
 };
 
 const mapStateToProps: (

--- a/web/src/containers/ListDetail.tsx
+++ b/web/src/containers/ListDetail.tsx
@@ -45,9 +45,10 @@ import withUser, { WithUserProps } from '../components/withUser';
 import { AppState } from '../reducers';
 import { ListsByIdMap } from '../reducers/lists';
 import { layoutStyles } from '../styles';
-import { List, Thing } from '../types';
+import { List } from '../types';
 import _ from 'lodash';
 import { StdRouterLink } from '../components/RouterLink';
+import { ThingMap } from '../reducers/item-detail';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -96,7 +97,7 @@ interface OwnProps {
   isAuthed?: boolean;
   listLoading: boolean;
   listsById: ListsByIdMap;
-  thingsById: { [key: number]: Thing };
+  thingsById: ThingMap;
 }
 
 interface DrawerProps {

--- a/web/src/containers/Lists.tsx
+++ b/web/src/containers/Lists.tsx
@@ -24,8 +24,9 @@ import { AppState } from '../reducers';
 import { ListsByIdMap } from '../reducers/lists';
 import { Loading } from '../reducers/user';
 import { layoutStyles } from '../styles';
-import { List as ListType, Thing } from '../types';
+import { List as ListType } from '../types';
 import _ from 'lodash';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({

--- a/web/src/containers/New.tsx
+++ b/web/src/containers/New.tsx
@@ -15,7 +15,7 @@ import { bindActionCreators } from 'redux';
 import withUser, { WithUserProps } from '../components/withUser';
 import { AppState } from '../reducers';
 import { layoutStyles } from '../styles';
-import { Thing, Availability } from '../types';
+import { Availability } from '../types';
 import {
   retrieveUpcomingAvailability,
   retrieveAllAvailability,
@@ -24,6 +24,7 @@ import { AvailabilityState } from '../reducers/availability';
 import _ from 'lodash';
 import ItemCard from '../components/ItemCard';
 import moment from 'moment';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -180,7 +181,7 @@ const mapStateToProps = (appState: AppState) => {
   return {
     isAuthed: !R.isNil(R.path(['auth', 'token'], appState)),
     isSearching: appState.search.searching,
-    searchResults: R.path<Thing[]>(['search', 'results', 'data'], appState),
+    searchResults: appState.search.results,
     upcoming: appState.availability.upcoming,
     expiring: appState.availability.expiring,
     recentlyAdded: appState.availability.recentlyAdded,

--- a/web/src/containers/Popular.tsx
+++ b/web/src/containers/Popular.tsx
@@ -19,7 +19,6 @@ import { bindActionCreators } from 'redux';
 import * as R from 'ramda';
 import { AppState } from '../reducers';
 import { layoutStyles } from '../styles';
-import { Thing } from '../types';
 import { retrievePopular } from '../actions/popular';
 import { getMetadataPath } from '../utils/metadata-access';
 import ItemCard from '../components/ItemCard';
@@ -27,6 +26,7 @@ import withUser, { WithUserProps } from '../components/withUser';
 import { ResponsiveImage } from '../components/ResponsiveImage';
 import AddToListDialog from '../components/AddToListDialog';
 import imagePlaceholder from '../assets/images/imagePlaceholder.png';
+import Thing from '../types/Thing';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -90,7 +90,6 @@ interface OwnProps extends WithStyles<typeof styles> {}
 interface InjectedProps {
   isAuthed: boolean;
   isSearching: boolean;
-  searchResults?: Thing[];
   popular?: string[];
   thingsBySlug: { [key: string]: Thing };
 }
@@ -293,7 +292,6 @@ const mapStateToProps = (appState: AppState) => {
   return {
     isAuthed: !R.isNil(R.path(['auth', 'token'], appState)),
     isSearching: appState.search.searching,
-    searchResults: R.path<Thing[]>(['search', 'results', 'data'], appState),
     popular: appState.popular.popular,
     thingsBySlug: appState.itemDetail.thingsBySlug,
   };

--- a/web/src/reducers/lists.ts
+++ b/web/src/reducers/lists.ts
@@ -16,8 +16,9 @@ import {
   LIST_RETRIEVE_SUCCESS,
   LIST_RETRIEVE_ALL_SUCCESS,
 } from '../actions/lists';
-import { List, Thing } from '../types';
+import { List } from '../types';
 import { flattenActions, handleAction } from './utils';
+import Thing from '../types/Thing';
 
 export type Loading = { [X in ListActions['type']]: boolean };
 

--- a/web/src/reducers/people.ts
+++ b/web/src/reducers/people.ts
@@ -1,10 +1,9 @@
-import { Person } from '../types';
 import { flattenActions, handleAction } from './utils';
-import * as R from 'ramda';
 import {
   PERSON_FETCH_SUCCESSFUL,
   PersonFetchSuccessfulAction,
 } from '../actions/people/get_person';
+import Person, { PersonFactory } from '../types/Person';
 
 export interface State {
   peopleById: { [key: string]: Person };
@@ -23,7 +22,7 @@ const personFetchSuccess = handleAction(
     let existingPerson: Person | undefined = peopleById[payload!.id];
     let newThing: Person = payload!;
     if (existingPerson) {
-      newThing = R.mergeDeepRight(existingPerson, newThing) as Person;
+      newThing = PersonFactory.merge(existingPerson, newThing);
     }
 
     // TODO: Truncate thingsById after a certain point

--- a/web/src/reducers/popular.ts
+++ b/web/src/reducers/popular.ts
@@ -1,4 +1,3 @@
-import { Thing } from '../types';
 import { handleAction, flattenActions } from './utils';
 import {
   PopularSuccessfulAction,
@@ -19,7 +18,7 @@ const PopularSuccess = handleAction<PopularSuccessfulAction, State>(
     if (payload) {
       return {
         ...state,
-        popular: R.map(R.prop('normalizedName'), payload.popular),
+        popular: R.map(t => t.slug, payload.popular),
       };
     } else {
       return state;

--- a/web/src/reducers/search.ts
+++ b/web/src/reducers/search.ts
@@ -6,8 +6,8 @@ import {
   SearchInitiatedAction,
   SearchSuccessfulAction,
 } from '../actions/search';
-import { Thing } from '../types';
 import { flattenActions, handleAction } from './utils';
+import Thing from '../types/Thing';
 
 export interface State {
   currentSearchText: string;
@@ -47,11 +47,15 @@ const searchInitiated = handleAction<SearchInitiatedAction, State>(
 const searchSuccess = handleAction<SearchSuccessfulAction, State>(
   SEARCH_SUCCESSFUL,
   (state, { payload }) => {
-    return {
-      ...state,
-      searching: false,
-      results: payload,
-    };
+    if (payload) {
+      return {
+        ...state,
+        searching: false,
+        results: payload.results,
+      };
+    } else {
+      return state;
+    }
   },
 );
 

--- a/web/src/types/HasImagery.ts
+++ b/web/src/types/HasImagery.ts
@@ -1,0 +1,5 @@
+export default interface HasImagery {
+  backdropPath: string | undefined;
+  posterPath: string | undefined;
+  profilePath: string | undefined;
+}

--- a/web/src/types/Person.ts
+++ b/web/src/types/Person.ts
@@ -1,0 +1,42 @@
+import { ThingLikeStruct } from './Thing';
+import { Person as TmdbPerson } from './external/themoviedb/Person';
+import HasImagery from './HasImagery';
+import * as R from 'ramda';
+import { PersonCredit, PersonCreditFactory } from './PersonCredit';
+
+export interface PersonStruct extends ThingLikeStruct {
+  metadata: TmdbPerson;
+}
+
+export interface ApiPerson extends PersonStruct {
+  type: 'person';
+}
+
+export default interface Person extends PersonStruct, HasImagery {
+  type: 'person';
+  // Calculated
+  castMemberOf: PersonCredit[];
+  biography?: string;
+  genreIds?: number[];
+}
+
+export class PersonFactory {
+  static create(apiPerson: ApiPerson): Person {
+    return {
+      ...apiPerson,
+      castMemberOf: apiPerson.metadata.combined_credits
+        ? (apiPerson.metadata.combined_credits.cast || []).map(
+            PersonCreditFactory.create,
+          )
+        : [],
+      biography: apiPerson.metadata.biography,
+      profilePath: apiPerson.metadata.profile_path,
+      backdropPath: undefined,
+      posterPath: undefined,
+    };
+  }
+
+  static merge(left: Person, right: Person) {
+    return R.mergeDeepRight(left, right) as Person;
+  }
+}

--- a/web/src/types/PersonCredit.ts
+++ b/web/src/types/PersonCredit.ts
@@ -1,0 +1,22 @@
+import HasImagery from './HasImagery';
+import { PersonCredit as TmdbPersonCredit } from './external/themoviedb/Person';
+
+export interface PersonCredit extends HasImagery {
+  genreIds?: number[];
+  popularity?: number;
+  releaseDate?: string;
+}
+
+export class PersonCreditFactory {
+  static create(person: TmdbPersonCredit): PersonCredit {
+    return {
+      ...person,
+      profilePath: undefined,
+      backdropPath: person.backdrop_path,
+      posterPath: person.poster_path,
+      genreIds: person.genre_ids,
+      popularity: person.popularity,
+      releaseDate: person.release_date,
+    };
+  }
+}

--- a/web/src/types/Thing.ts
+++ b/web/src/types/Thing.ts
@@ -1,0 +1,103 @@
+import { ObjectMetadata } from './external/themoviedb/Movie';
+import {
+  ActionType,
+  Availability,
+  CastMember,
+  ThingUserMetadata,
+} from './index';
+import * as R from 'ramda';
+import {
+  getBackdropPath,
+  getDescription,
+  getMetadataPath,
+  getPosterPath,
+  getProfilePath,
+} from '../utils/metadata-access';
+import HasImagery from './HasImagery';
+
+export const itemHasTag = (thing: ThingLikeStruct, expectedTag: ActionType) => {
+  if (thing.userMetadata) {
+    return R.any(tag => {
+      return tag.action == expectedTag;
+    }, thing.userMetadata.tags);
+  }
+
+  return false;
+};
+
+export interface ThingLikeStruct {
+  id: string;
+  name: string;
+  normalizedName: string;
+  type: 'movie' | 'show' | 'person';
+  userMetadata?: ThingUserMetadata;
+}
+
+export interface HasThingMetadata {
+  metadata?: ObjectMetadata;
+}
+
+export interface HasAvailability {
+  availability: Availability[];
+}
+
+export interface HasCast {
+  cast?: CastMember[];
+}
+
+export interface HasDescription {
+  description?: string;
+}
+
+export interface Linkable {
+  relativeUrl: string;
+}
+
+export interface ApiThing
+  extends ThingLikeStruct,
+    HasThingMetadata,
+    HasAvailability,
+    HasCast {}
+
+export default interface Thing
+  extends ThingLikeStruct,
+    HasImagery,
+    HasThingMetadata,
+    HasAvailability,
+    HasCast,
+    HasDescription,
+    Linkable {
+  // Calculated
+  slug: string;
+  itemMarkedAsWatched: boolean;
+  runtime?: number;
+}
+
+export class ThingFactory {
+  static create(
+    apiThing: ThingLikeStruct & HasAvailability & HasCast & HasThingMetadata,
+  ): Thing {
+    return {
+      ...apiThing,
+
+      // Calculated fields
+      slug: apiThing.normalizedName,
+      relativeUrl: `/${apiThing.type}/${apiThing.normalizedName}`,
+      description: getDescription(apiThing),
+      itemMarkedAsWatched: itemHasTag(apiThing, ActionType.Watched),
+      runtime:
+        apiThing.type === 'movie'
+          ? getMetadataPath<number>(apiThing, 'runtime')
+          : getMetadataPath<number>(apiThing, 'episode_run_time'),
+
+      // Images
+      posterPath: getPosterPath(apiThing),
+      backdropPath: getBackdropPath(apiThing),
+      profilePath: getProfilePath(apiThing),
+    };
+  }
+
+  static merge(left: Thing, right: Thing): Thing {
+    return R.mergeDeepRight(left, right) as Thing;
+  }
+}

--- a/web/src/types/ThingLike.ts
+++ b/web/src/types/ThingLike.ts
@@ -1,0 +1,31 @@
+import { ThingLikeStruct } from './Thing';
+
+export default abstract class ThingLike<Underlying extends ThingLikeStruct> {
+  protected readonly underlying: Underlying;
+
+  protected constructor(underlying: Underlying) {
+    this.underlying = underlying;
+  }
+
+  get raw(): Underlying {
+    return this.underlying;
+  }
+
+  get id(): string {
+    return this.underlying.id;
+  }
+
+  get name(): string {
+    return this.underlying.name;
+  }
+
+  get normalizedName(): string {
+    return this.raw.normalizedName;
+  }
+
+  get slug(): string {
+    return this.raw.normalizedName;
+  }
+
+  abstract get type(): 'movie' | 'show' | 'person';
+}

--- a/web/src/types/external/themoviedb/Person.ts
+++ b/web/src/types/external/themoviedb/Person.ts
@@ -1,35 +1,61 @@
 export interface Person {
-    adult?: boolean
-    also_known_as?: object[]
-    biography?: string
-    birthday?: string
-    deathday?: string
-    gender?: number
-    homepage?: string
-    id: number
-    imdb_id?: string
-    name?: string
-    place_of_birth?: string
-    popularity?: number
-    profile_path?: string
+  adult?: boolean;
+  also_known_as?: object[];
+  biography?: string;
+  birthday?: string;
+  deathday?: string;
+  gender?: number;
+  homepage?: string;
+  id: number;
+  imdb_id?: string;
+  name?: string;
+  place_of_birth?: string;
+  popularity?: number;
+  profile_path?: string;
+  combined_credits?: PersonCredits;
+}
+
+export interface PersonCredits {
+  cast?: PersonCredit[];
+  crew?: PersonCredit[];
+}
+
+export interface PersonCredit {
+  adult?: boolean;
+  backdrop_path?: string;
+  genre_ids?: number[];
+  id: number;
+  character?: string;
+  media_type?: string;
+  original_language?: string;
+  original_title?: string;
+  overview?: string;
+  popularity?: number;
+  poster_path?: string;
+  release_date?: string;
+  name?: string;
+  title?: string;
+  video?: boolean;
+  vote_average?: number;
+  vote_count?: number;
 }
 
 export interface CastMember {
-    character?: string
-    credit_id?: string
-    gender?: number
-    id: number
-    name?: string
-    order?: number
-    profile_path?: string
+  character?: string;
+  credit_id?: string;
+  gender?: number;
+  id: number;
+  name?: string;
+  order?: number;
+  profile_path?: string;
 }
 
 export interface CrewMember {
-    credit_id?: string
-    department?: string
-    gender?: number
-    id: number
-    job?: string
-    name?: string
-    profile_path?: string
+  credit_id?: string;
+  department?: string;
+  gender?: number;
+  id: number;
+  job?: string;
+  name?: string;
+  profile_path?: string;
 }

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,4 +1,5 @@
 import { ObjectMetadata } from './external/themoviedb/Movie';
+import Thing from './Thing';
 
 export interface List {
   id: number;
@@ -54,30 +55,6 @@ export interface CastMember {
   characterName?: string;
   relation?: string;
   tmdbId?: string;
-}
-
-abstract class HasImagery {
-  abstract getBackdropPath();
-  abstract getPosterPath();
-  abstract getProfilePath(): string | undefined;
-}
-
-interface ThingLike {
-  id: string;
-  name: string;
-  normalizedName: string;
-  type: 'movie' | 'show' | 'person';
-  metadata?: ObjectMetadata;
-  userMetadata?: ThingUserMetadata;
-  availability: Availability[];
-}
-
-export interface Thing extends ThingLike {
-  cast?: CastMember[];
-}
-
-export interface Person extends ThingLike {
-  type: 'person';
 }
 
 export interface ThingUserMetadata {

--- a/web/src/utils/api-client.ts
+++ b/web/src/utils/api-client.ts
@@ -1,9 +1,9 @@
 import * as apisauce from 'apisauce';
 import { merge } from 'ramda';
-import { List, User, Network, ActionType, UserPreferences } from '../types';
+import { ActionType, List, Network, User, UserPreferences } from '../types';
 import { KeyMap, ObjectMetadata } from '../types/external/themoviedb/Movie';
-import { Thing } from '../types';
 import _ from 'lodash';
+import { ApiThing } from '../types/Thing';
 
 export interface TeletrackerApiOptions {
   url?: string;
@@ -102,7 +102,7 @@ export class TeletrackerApi {
   }
 
   async search(token: string, searchText: string) {
-    return this.api.get<Thing[]>('/api/v2/search', {
+    return this.api.get<ApiThing[]>('/api/v2/search', {
       query: searchText,
       token,
     });

--- a/web/src/utils/metadata-access.ts
+++ b/web/src/utils/metadata-access.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
-import { Thing } from '../types';
-
-const tmdbMetadataPath = ['metadata', 'themoviedb'];
+import Thing, { HasThingMetadata } from '../types/Thing';
+// import { Thing } from '../types';
 
 const makePath = (typ: string, field: string) => {
   return ['metadata', 'themoviedb', typ, field];
@@ -23,31 +22,38 @@ const fallbacks = function<T, U>(x: ((x: T) => U | undefined)[]) {
 const extractor = <T = string>(field: string) =>
   ['movie', 'show']
     .map(t => makePath(t, field))
-    .map(p => _.property<Thing, T>(p));
+    .map(p => _.property<HasThingMetadata, T>(p));
 
 // Provides the path of metadata
-export const getMetadataPath = (item: Thing, metadata: string) => {
-  return fallbacks<Thing, any>(extractor(metadata))(item);
+export const getMetadataPath = <T = any>(
+  item: HasThingMetadata,
+  metadata: string,
+) => {
+  return fallbacks<HasThingMetadata, T>(extractor(metadata))(item);
 };
 
-export const getPosterPath = (item: Thing) => {
-  return fallbacks<Thing, string>(extractor('poster_path'))(item);
+export const getPosterPath = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('poster_path'))(item);
 };
 
-export const getBackdropPath = (item: Thing) => {
-  return fallbacks<Thing, string>(extractor('backdrop_path'))(item);
+export const getBackdropPath = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('backdrop_path'))(item);
 };
 
-export const getTitlePath = (item: Thing) => {
-  return fallbacks<Thing, string>(extractor('title'))(item);
+export const getProfilePath = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('profile_path'))(item);
 };
 
-export const getOverviewPath = (item: Thing) => {
-  return fallbacks<Thing, string>(extractor('overview'))(item);
+export const getTitlePath = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('title'))(item);
 };
 
-export const getVoteAveragePath = (item: Thing) => {
-  return fallbacks<Thing, string>(extractor('vote_average'))(item);
+export const getOverviewPath = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('overview'))(item);
+};
+
+export const getVoteAveragePath = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('vote_average'))(item);
 };
 
 type BackdropUrlSize = '300' | '780' | '1280' | 'original';
@@ -82,6 +88,6 @@ export const getBackdropUrl = (item: Thing, size: BackdropUrlSize) => {
   if (path) return makeUrl(path, size);
 };
 
-export const getDescription = (item: Thing) => {
-  return fallbacks<Thing, string>(extractor('overview'))(item);
+export const getDescription = (item: HasThingMetadata) => {
+  return fallbacks<HasThingMetadata, string>(extractor('overview'))(item);
 };


### PR DESCRIPTION
Refactoring of Thing and Person into more flexible interfaces

Idea here is that "Thing" is now a combination of the following:
* The raw "Thing" returned from the API: called ApiThing
* A bag of precomputed values (relativeUrl, etc)

Additionally, some common fields on Thing are extracted to their own interfaces to allow for components to be more granular and just request a compound type for the data they need. Example: https://github.com/chrisbenincasa/teletracker/compare/thing-class?expand=1#diff-fafafedc00ebf615dd0645c78be9f4c5R190

