### PR TITLE
Fixes known empty drawer bug

### DIFF
--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -110,7 +110,6 @@ interface DispatchProps {
 
 interface State {
   createDialogOpen: boolean;
-  loadingLists: boolean;
   authModalOpen: boolean;
   authModalScreen?: 'login' | 'signup';
 }
@@ -180,7 +179,6 @@ const ListItemLink = withStyles(styles, { withTheme: true })(
 class Drawer extends Component<Props, State> {
   state: State = {
     createDialogOpen: false,
-    loadingLists: true,
     authModalOpen: false,
     authModalScreen: 'login',
   };
@@ -188,12 +186,6 @@ class Drawer extends Component<Props, State> {
   componentDidMount() {
     if (this.props.isAuthed) {
       this.props.retrieveAllLists({ includeThings: false });
-    }
-  }
-
-  componentDidUpdate(oldProps: Props) {
-    if (Boolean(oldProps.loadingLists) && !Boolean(this.props.loadingLists)) {
-      this.setState({ loadingLists: false });
     }
   }
 
@@ -340,6 +332,10 @@ class Drawer extends Component<Props, State> {
     );
   }
 
+  isLoading() {
+    return this.props.loadingLists || !this.props.userSelf;
+  }
+
   render() {
     return (
       <React.Fragment>
@@ -354,12 +350,6 @@ class Drawer extends Component<Props, State> {
           initialForm={this.state.authModalScreen}
         />
       </React.Fragment>
-    );
-  }
-
-  isLoading() {
-    return (
-      this.state.loadingLists || this.props.loadingLists || !this.props.userSelf
     );
   }
 }


### PR DESCRIPTION
We had listLoading state in the drawer that checked for a prop listLoading change.  I think maybe the original use case here was to force an update on prop change? I'm not exactly sure, but after removing it things worked as expected.  I tested creating a new list and ensuring that the list appeared without refresh, which it did.

Let me know if there is more backstory to this piece of code, if so, I can adjust as necessary.

Fixes: https://github.com/chrisbenincasa/teletracker/issues/368