### PR TITLE
Fixes issue in itemDetail page

### DIFF
--- a/web/src/containers/ItemDetail.tsx
+++ b/web/src/containers/ItemDetail.tsx
@@ -404,8 +404,6 @@ function ItemDetails(props: Props) {
       itemType = 'TVSeries';
     }
 
-    console.log(isFetching, ' ', itemDetail);
-
     return isFetching || !itemDetail ? (
       renderLoading()
     ) : (


### PR DESCRIPTION
This code caused an issue where every time the drawer was opened it would reload the ItemDetail page.  We have no need to reload the items when the URL params change because it will happen automatically when it mounts.