### PR TITLE
Fix "All" button in PeopleDetail filters

### DIFF
--- a/web/src/containers/PersonDetail.tsx
+++ b/web/src/containers/PersonDetail.tsx
@@ -277,7 +277,8 @@ class PersonDetail extends React.Component<Props, State> {
                 (genresFilter && genresFilter.length > 0 && genresFilter[0]) ||
                   0,
               )) ||
-          !genresFilter,
+          !genresFilter ||
+          genresFilter.length === 0,
       )
       .filter(
         credit =>
@@ -287,11 +288,11 @@ class PersonDetail extends React.Component<Props, State> {
           !itemTypes,
       )
       .sort((a, b) => {
-        if (this.state.filters.sortOrder === 'popularity') {
+        if (sortOrder === 'popularity') {
           return (a.item!.popularity || 0.0) < (b.item!.popularity || 0.0)
             ? 1
             : -1;
-        } else if (this.state.filters.sortOrder === 'recent') {
+        } else if (sortOrder === 'recent') {
           let sort;
           if (!b.item!.release_date) {
             sort = 1;
@@ -305,27 +306,6 @@ class PersonDetail extends React.Component<Props, State> {
           return 0;
         }
       });
-
-    let finalGenres: Genre[] = [];
-
-    if (this.props.genres) {
-      finalGenres = _.chain(filmography)
-        .map(f => f.item!.genres || [])
-        .flatten()
-        .map(f => f.id)
-        .uniq()
-        .map(id => {
-          let g = _.find(this.props.genres, g => g.id === id);
-          if (g) {
-            return [g];
-          } else {
-            return [];
-          }
-        })
-        .flatten()
-        .sortBy(g => g.name)
-        .value();
-    }
 
     return (
       <div className={classes.genreContainer}>


### PR DESCRIPTION
"All" button now resets filtering to display all items again:
![image](https://user-images.githubusercontent.com/6005331/68512258-e539f080-0245-11ea-8295-e34649f0752d.png)

The logic for this filtering is jank though and doesn't work in the best way and is limited in other ways.  Opening a ticket to do a refactor on that.

Fixes: https://github.com/chrisbenincasa/teletracker/issues/374