### PR TITLE
Close drawer on logout

### DIFF
--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -224,6 +224,7 @@ class Drawer extends Component<Props, State> {
 
   handleLogout = () => {
     this.props.logout();
+    this.props.closeRequested();
   };
 
   toggleAuthModal = (initialForm?: 'login' | 'signup') => {
@@ -410,6 +411,11 @@ const mapDispatchToProps = (dispatch: Dispatch) =>
 
 export default withWidth()(
   withStyles(styles, { withTheme: true })(
-    withRouter(connect(mapStateToProps, mapDispatchToProps)(Drawer)),
+    withRouter(
+      connect(
+        mapStateToProps,
+        mapDispatchToProps,
+      )(Drawer),
+    ),
   ),
 );


### PR DESCRIPTION
When you logout via the drawer, it will now close, matching the experience if you logout anywhere else.

Fixes: https://github.com/chrisbenincasa/teletracker/issues/186