### PR TITLE
Updates and fixes for "Mark as Watched" and Fabs

### DIFF
--- a/web/src/components/ManageTracking.tsx
+++ b/web/src/components/ManageTracking.tsx
@@ -1,6 +1,6 @@
 import {
+  Button,
   createStyles,
-  Fab,
   Theme,
   WithStyles,
   withStyles,
@@ -16,7 +16,7 @@ import { itemBelongsToLists } from '../types/v2/Item';
 const styles = (theme: Theme) =>
   createStyles({
     button: {
-      marginTop: 5,
+      marginTop: theme.spacing(1),
       width: '100% !important',
       [theme.breakpoints.down('xs')]: {
         fontSize: '0.55rem',
@@ -24,7 +24,7 @@ const styles = (theme: Theme) =>
       fontSIze: '2rem',
     },
     buttonIcon: {
-      marginRight: 8,
+      marginRight: theme.spacing(1),
       [theme.breakpoints.down('sm')]: {
         fontSize: '1rem',
       },
@@ -63,11 +63,11 @@ class ManageTracking extends Component<Props, State> {
     };
   }
 
-  toggleLoginModal = () => {
+  toggleLoginModal = (): void => {
     this.setState({ loginModalOpen: !this.state.loginModalOpen });
   };
 
-  openManageTrackingModal = () => {
+  openManageTrackingModal = (): void => {
     if (this.props.userSelf) {
       this.setState({ manageTrackingModalOpen: true });
     } else {
@@ -75,7 +75,7 @@ class ManageTracking extends Component<Props, State> {
     }
   };
 
-  closeManageTrackingModal = () => {
+  closeManageTrackingModal = (): void => {
     this.setState({ manageTrackingModalOpen: false });
   };
 
@@ -87,16 +87,16 @@ class ManageTracking extends Component<Props, State> {
 
     return (
       <div className={classes.itemCTA} style={{ ...style }}>
-        <Fab
+        <Button
           size="small"
-          variant="extended"
-          aria-label="Add"
+          variant="contained"
+          aria-label="Add to List"
           onClick={this.openManageTrackingModal}
           className={classes.button}
+          startIcon={<ListIcon className={classes.buttonIcon} />}
         >
-          <ListIcon className={classes.buttonIcon} />
           {trackingCTA}
-        </Fab>
+        </Button>
       </div>
     );
   };
@@ -110,13 +110,13 @@ class ManageTracking extends Component<Props, State> {
         {this.renderTrackingToggle()}
         <AddToListDialog
           open={manageTrackingModalOpen}
-          onClose={this.closeManageTrackingModal.bind(this)}
+          onClose={this.closeManageTrackingModal}
           userSelf={userSelf!}
           item={itemDetail}
         />
         <AuthDialog
           open={this.state.loginModalOpen}
-          onClose={() => this.toggleLoginModal()}
+          onClose={this.toggleLoginModal}
         />
       </React.Fragment>
     );

--- a/web/src/containers/ItemDetail.tsx
+++ b/web/src/containers/ItemDetail.tsx
@@ -1,10 +1,10 @@
 import {
   Backdrop,
+  Button,
   CardMedia,
   Chip,
   createStyles,
   Dialog,
-  Fab,
   Fade,
   Hidden,
   IconButton,
@@ -515,16 +515,16 @@ function ItemDetails(props: Props) {
               alignItems: 'flex-start',
             }}
           >
-            <Fab
+            <Button
               size="small"
               onClick={history.goBack}
-              variant="extended"
+              variant="contained"
               aria-label="Go Back"
               style={{ marginTop: 20, marginLeft: 20 }}
+              startIcon={<ChevronLeft style={{ marginRight: 8 }} />}
             >
-              <ChevronLeft style={{ marginRight: 8 }} />
               Go Back
-            </Fab>
+            </Button>
 
             <div
               className={classes.itemDetailContainer}

--- a/web/src/containers/PersonDetail.tsx
+++ b/web/src/containers/PersonDetail.tsx
@@ -1,6 +1,6 @@
 import {
+  Button,
   createStyles,
-  Fab,
   Grid,
   Hidden,
   IconButton,
@@ -36,6 +36,7 @@ import AllFilters from '../components/Filters/AllFilters';
 import ActiveFilters from '../components/Filters/ActiveFilters';
 import { FilterParams } from '../utils/searchFilters';
 import { parseFilterParamsFromQs } from '../utils/urlHelper';
+import classes from '*.module.css';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -119,6 +120,13 @@ const styles = (theme: Theme) =>
       display: 'flex',
       alignSelf: 'flex-end',
     },
+    titleContainer: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      width: '80%',
+      marginBottom: 10,
+    },
   });
 
 interface OwnProps {}
@@ -197,16 +205,9 @@ class PersonDetail extends React.Component<Props, State> {
   };
 
   renderTitle = (person: Person) => {
+    const { classes } = this.props;
     return (
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          width: '80%',
-          marginBottom: 10,
-        }}
-      >
+      <div className={classes.titleContainer}>
         <Typography color="inherit" variant="h4">
           {`${person.name}`}
         </Typography>
@@ -266,7 +267,7 @@ class PersonDetail extends React.Component<Props, State> {
   renderFilmography = () => {
     const { classes, genres, person, userSelf } = this.props;
     const {
-      filters: { genresFilter, itemTypes, networks, sortOrder },
+      filters: { genresFilter, itemTypes, sortOrder },
     } = this.state;
 
     let filmography = person!.cast_credits || [];
@@ -387,9 +388,9 @@ class PersonDetail extends React.Component<Props, State> {
             {showFullBiography ? biography : biography.substr(0, 1200)}
           </Typography>
           {biography.length > 1200 ? (
-            <Fab
+            <Button
               size="small"
-              variant="extended"
+              variant="contained"
               aria-label={showFullBiography ? 'Read Less' : 'Read More'}
               onClick={this.showFullBiography}
               style={{ marginTop: 5, display: 'flex', alignSelf: 'center' }}
@@ -400,7 +401,7 @@ class PersonDetail extends React.Component<Props, State> {
                 <ExpandMore style={{ marginRight: 8 }} />
               )}
               {showFullBiography ? 'Read Less' : 'Read More'}
-            </Fab>
+            </Button>
           ) : null}
         </div>
       </div>
@@ -408,7 +409,7 @@ class PersonDetail extends React.Component<Props, State> {
   };
 
   renderPerson() {
-    let { classes, person, userSelf } = this.props;
+    let { classes, person } = this.props;
 
     if (!person) {
       return this.renderLoading();
@@ -424,12 +425,16 @@ class PersonDetail extends React.Component<Props, State> {
           <meta
             name="title"
             property="og:title"
-            content={`${person.name} | Where to stream, rent, or buy. Track this person today!`}
+            content={`${
+              person.name
+            } | Where to stream, rent, or buy. Track this person today!`}
           />
           <meta
             name="description"
             property="og:description"
-            content={`Find out where to stream, rent, or buy content featuring ${person.name} online. Track it to find out when it's available on one of your services.`}
+            content={`Find out where to stream, rent, or buy content featuring ${
+              person.name
+            } online. Track it to find out when it's available on one of your services.`}
           />
           <meta
             name="image"
@@ -455,11 +460,15 @@ class PersonDetail extends React.Component<Props, State> {
           />
           <meta
             name="twitter:title"
-            content={`${person.name} - Where to Stream, Rent, or Buy their content`}
+            content={`${
+              person.name
+            } - Where to Stream, Rent, or Buy their content`}
           />
           <meta
             name="twitter:description"
-            content={`Find out where to stream, rent, or buy content featuring ${person.name} online. Track it to find out when it's available on one of your services.`}
+            content={`Find out where to stream, rent, or buy content featuring ${
+              person.name
+            } online. Track it to find out when it's available on one of your services.`}
           />
           <meta
             name="twitter:image"
@@ -467,7 +476,9 @@ class PersonDetail extends React.Component<Props, State> {
           />
           <meta
             name="keywords"
-            content={`${person.name}, stream, streaming, rent, buy, watch, track`}
+            content={`${
+              person.name
+            }, stream, streaming, rent, buy, watch, track`}
           />
           <link
             rel="canonical"
@@ -499,16 +510,16 @@ class PersonDetail extends React.Component<Props, State> {
               alignItems: 'flex-start',
             }}
           >
-            <Fab
+            <Button
               size="small"
               onClick={this.props.history.goBack}
-              variant="extended"
+              variant="contained"
               aria-label="Go Back"
               style={{ marginTop: 20, marginLeft: 20 }}
             >
               <ChevronLeft style={{ marginRight: 8 }} />
               Go Back
-            </Fab>
+            </Button>
 
             <div className={classes.personDetailContainer}>
               <div className={classes.leftContainer}>
@@ -569,6 +580,11 @@ const mapDispatchToProps: (dispatch: Dispatch) => DispatchProps = dispatch =>
 
 export default withUser(
   withStyles(styles)(
-    withRouter(connect(mapStateToProps, mapDispatchToProps)(PersonDetail)),
+    withRouter(
+      connect(
+        mapStateToProps,
+        mapDispatchToProps,
+      )(PersonDetail),
+    ),
   ),
 );

--- a/web/src/types/Thing.ts
+++ b/web/src/types/Thing.ts
@@ -88,7 +88,7 @@ export default interface Thing
   recommendations?: Thing[];
   genreIds?: number[];
   popularity?: number;
-  releaseDate?: number;
+  release_date?: number;
 }
 
 export class ThingFactory {


### PR DESCRIPTION
- Removes ability to mark an item as watched if it's unreleased:
![image](https://user-images.githubusercontent.com/6005331/68632822-baf26800-04bd-11ea-996a-d3d2c6347517.png)
- Otherwise shows it as normally (but using Buttons now):
![image](https://user-images.githubusercontent.com/6005331/68632852-d2315580-04bd-11ea-9748-57db8ff4323a.png)
- Display "Mark as Watched" for everyone and if you aren't logged in, display login screen:
![image](https://user-images.githubusercontent.com/6005331/68632872-e5442580-04bd-11ea-96d7-073b82cfe3dc.png)

- According to Material spec FAB is the right choice for the buts we've been using them for, so I moved them to just be Buttons...
> A floating action button (FAB) performs the primary, or most common, action on a screen.
> Only use a FAB if it is the most suitable way to present a screen’s primary action.
> Only one floating action button is recommended per screen to represent the most common action.