### PR TITLE
Created 404 page

### DIFF
--- a/web/src/containers/App.tsx
+++ b/web/src/containers/App.tsx
@@ -33,6 +33,7 @@ import Toolbar from '../components/Toolbar/Toolbar';
 import Footer from '../components/Footer';
 import Logout from './Logout';
 import Explore from './Explore';
+import NoMatch404 from './NoMatch404';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -191,6 +192,7 @@ class App extends Component<Props, State> {
                     path="/:type/:id"
                     render={props => <ItemDetail {...props} />}
                   />
+                  <Route component={NoMatch404} />
                 </Switch>
               </main>
             </div>

--- a/web/src/containers/NoMatch404.tsx
+++ b/web/src/containers/NoMatch404.tsx
@@ -1,0 +1,57 @@
+import {
+  createStyles,
+  Theme,
+  Typography,
+  withStyles,
+  WithStyles,
+} from '@material-ui/core';
+import React, { Component } from 'react';
+import ReactGA from 'react-ga';
+import { GA_TRACKING_ID } from '../constants';
+import { Helmet } from 'react-helmet';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    wrapper: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: '70vh',
+      width: '100%',
+    },
+  });
+
+interface OwnProps extends WithStyles<typeof styles> {}
+
+type Props = OwnProps;
+
+class NoMatch404 extends Component<Props> {
+  componentDidMount(): void {
+    ReactGA.initialize(GA_TRACKING_ID);
+    const page = window.location.pathname + window.location.search;
+    ReactGA.pageview(page);
+    ReactGA.event({
+      category: '404',
+      action: page,
+      value: 1,
+      nonInteraction: true,
+    });
+  }
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <React.Fragment>
+        <Helmet>
+          <title>{`404 | Teletracker`}</title>
+        </Helmet>
+        <div className={classes.wrapper}>
+          <Typography variant="h1">404</Typography>
+        </div>
+      </React.Fragment>
+    );
+  }
+}
+
+export default withStyles(styles)(NoMatch404);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6005331/69002203-47cf6400-08b8-11ea-98c5-0e42cf98e78a.png)

We could probably find some fun movie quotes/images to use on the 404.  For now, this is setup to track 404 pages for us.  This is technically a soft-404, as it should still return a 200 when you access the page.  We'll either need to add this file into the robots.txt or figure out how to make sure google doesn't index this on their end.  From what I read it sounds like google blacklists the page if they think it's a soft 404, which isn't the worse thing in the world but prob better for us to control it on our end.

Resolves: https://github.com/chrisbenincasa/teletracker/issues/414