### PR TITLE
Improvements to free text search

### DIFF
--- a/scala-server/common/src/main/scala/com/teletracker/common/elasticsearch/ItemSearch.scala
+++ b/scala-server/common/src/main/scala/com/teletracker/common/elasticsearch/ItemSearch.scala
@@ -25,6 +25,7 @@ import org.elasticsearch.common.lucene.search.function.FieldValueFactorFunction
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders
 import org.elasticsearch.index.query.{
   BoolQueryBuilder,
+  MultiMatchQueryBuilder,
   Operator,
   QueryBuilders,
   TermQueryBuilder
@@ -54,9 +55,16 @@ class ItemSearch @Inject()(
       .boolQuery()
       .must(
         QueryBuilders
-          .matchQuery("original_title", textQuery)
+          .multiMatchQuery(
+            textQuery,
+            "title",
+            "title._2gram",
+            "title._3gram"
+          )
+          .`type`(MultiMatchQueryBuilder.Type.BOOL_PREFIX)
           .operator(Operator.AND)
       )
+      .through(posterImageFilter)
       .through(removeAdultItems)
       .applyOptional(searchOptions.thingTypeFilter.filter(_.nonEmpty))(
         (builder, types) => types.foldLeft(builder)(itemTypeFilter)


### PR DESCRIPTION
Takes full advantage of the "search_as_you_type" special type we use to index English titles (in the "title") field. This gives a vast improvement when returning results for prefix searches (i.e. while you're typing). Additionally, full-text search now purposefully excludes items w/o a poster image.

## Examples:
### Search: "World According"
#### qa.teletracker.tv
<img width="1792" alt="Screen Shot 2019-11-19 at 5 36 50 PM" src="https://user-images.githubusercontent.com/1640671/69198981-cfed7d80-0af3-11ea-9f5e-cb2bfedc3c0a.png">

#### localhost with these changes
<img width="1792" alt="Screen Shot 2019-11-19 at 5 36 46 PM" src="https://user-images.githubusercontent.com/1640671/69198997-df6cc680-0af3-11ea-91c3-988522399670.png">

#### reelgood
<img width="1792" alt="Screen Shot 2019-11-19 at 5 36 53 PM" src="https://user-images.githubusercontent.com/1640671/69199008-ebf11f00-0af3-11ea-8025-dde71e35f3f2.png">

### Search: "World Accord"
#### qa.teletracker.tv
<img width="1792" alt="Screen Shot 2019-11-19 at 5 37 17 PM" src="https://user-images.githubusercontent.com/1640671/69199024-ff03ef00-0af3-11ea-8e09-920610c8d96e.png">

#### localhost with these changes
<img width="1792" alt="Screen Shot 2019-11-19 at 5 43 37 PM" src="https://user-images.githubusercontent.com/1640671/69199069-2bb80680-0af4-11ea-8896-c244e68cb136.png">

#### reelgood
<img width="1792" alt="Screen Shot 2019-11-19 at 5 37 18 PM" src="https://user-images.githubusercontent.com/1640671/69199074-307cba80-0af4-11ea-8297-99e0dd1fcd9a.png">

