### PR TITLE
Fix a few frontend issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ out/
 codebuild_build.sh
 
 localcerts/
+_localcertsold/

--- a/scripts/gen-certs
+++ b/scripts/gen-certs
@@ -7,7 +7,12 @@ set -o pipefail         # Use last non-zero exit code in a pipeline
 
 # https://medium.com/@tbusser/creating-a-browser-trusted-self-signed-ssl-certificate-2709ce43fd15
 
-openssl genrsa -des3 -out rootCA.key 2048
-openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024  -out rootCA.pem
-openssl req -new -nodes -out server.csr -newkey rsa:2048 -keyout server.key
-openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 500 -sha256 -extfile v3.ext
+#openssl genrsa -des3 -out rootCA.key 2048
+#openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 1024  -out rootCA.pem
+#openssl req -new -nodes -out server.csr -newkey rsa:2048 -keyout server.key
+#openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 500 -sha256 -extfile v3.ext
+
+openssl req -x509 -nodes -new -sha256 -days 1024 -newkey rsa:2048 -keyout RootCA.key -out RootCA.pem -subj "/C=US/CN=Example-Root-CA"
+openssl x509 -outform pem -in RootCA.pem -out RootCA.crt
+openssl req -new -nodes -newkey rsa:2048 -keyout localhost.key -out localhost.csr -subj "/C=US/ST=CO/L=Denver/O=Example-Certificates/CN=localhost.local"
+openssl x509 -req -sha256 -days 1024 -in localhost.csr -CA RootCA.pem -CAkey RootCA.key -CAcreateserial -extfile v3.ext -out localhost.crt

--- a/web/server.js
+++ b/web/server.js
@@ -13,8 +13,8 @@ const app = next({ dev });
 const handle = app.getRequestHandler();
 
 const httpsOptions = {
-  key: fs.readFileSync('../localcerts/server.key'),
-  cert: fs.readFileSync('../localcerts/server.crt'),
+  key: fs.readFileSync('../localcerts/localhost.key'),
+  cert: fs.readFileSync('../localcerts/localhost.crt'),
 };
 
 if (process.env.NODE_ENV !== 'production') {
@@ -60,6 +60,6 @@ app.prepare().then(() => {
     });
   }).listen(3000, err => {
     if (err) throw err;
-    console.log('> Ready on https://localhost:3000');
+    console.log(`> Ready on http${enableHttps ? 's' : ''}://localhost:3000`);
   });
 });

--- a/web/src/actions/people/get_credits.ts
+++ b/web/src/actions/people/get_credits.ts
@@ -65,6 +65,7 @@ export const fetchPersonCreditsDetailsSaga = function*() {
         payload.filterParams,
         payload.limit,
         payload.bookmark,
+        ['cast'],
       );
 
       if (response.ok) {

--- a/web/src/components/Auth/LoginForm.tsx
+++ b/web/src/components/Auth/LoginForm.tsx
@@ -18,6 +18,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {
   login,
+  LoginRedirect,
   LoginState,
   LoginSuccessful,
   logInWithGoogle,
@@ -167,13 +168,19 @@ class LoginForm extends Component<Props, State> {
     if (query) {
       path += `?${query};`;
     }
+
+    let redirect: LoginRedirect | undefined;
+    if (path !== '/login') {
+      redirect = {
+        route: path,
+        asPath: this.props.router.asPath,
+        query: this.props.router.query,
+      };
+    }
+
     this.props.logInWithGoogle({
       state: {
-        redirect: {
-          route: path,
-          asPath: this.props.router.asPath,
-          query: this.props.router.query,
-        },
+        redirect,
       },
     });
   };

--- a/web/src/components/Dialogs/CreateDynamicListDialog.tsx
+++ b/web/src/components/Dialogs/CreateDynamicListDialog.tsx
@@ -263,8 +263,9 @@ export default function CreateDynamicListDialog(props: Props) {
     }
   };
 
-  const defaultSort: ListDefaultSort | undefined =
-    filters.sortOrder !== 'default' ? { sort: filters.sortOrder } : undefined;
+  const defaultSort: ListDefaultSort | undefined = filters.sortOrder
+    ? { sort: filters.sortOrder }
+    : undefined;
 
   const validateListName = () => {
     let validateResult = CreateAListValidator.validate(existingLists, listName);

--- a/web/src/components/Filters/ActiveFilters.tsx
+++ b/web/src/components/Filters/ActiveFilters.tsx
@@ -46,6 +46,7 @@ interface Props {
   initialState?: FilterParams;
   variant?: 'default' | 'outlined';
   hideSortOptions?: boolean;
+  defaultSort?: SortOptions;
 }
 
 export const prettyItemType = (itemType: ItemType) => {
@@ -63,8 +64,6 @@ export const prettySort = (sortOption: SortOptions) => {
       return 'Added Time';
     case 'popularity':
       return 'Popularity';
-    case 'default':
-      return 'Default';
     case 'recent':
       return 'Release Date';
   }
@@ -72,7 +71,6 @@ export const prettySort = (sortOption: SortOptions) => {
 
 export default function ActiveFilters(props: Props) {
   const classes = useStyles();
-  // const history = useHistory();
   const router = useRouter();
   const { genres, initialState, isListDynamic, variant } = props;
   let {
@@ -161,10 +159,8 @@ export default function ActiveFilters(props: Props) {
   const deleteSort = (
     sort: SortOptions,
   ): [SortOptions | undefined, boolean] => {
-    const cleanSort = sort === 'default' ? undefined : sort;
-
     if (sort !== sortOrder) {
-      return [cleanSort, true];
+      return [sort, true];
     }
 
     return [sort, false];
@@ -268,7 +264,8 @@ export default function ActiveFilters(props: Props) {
       !(
         (isListDynamic && sortOrder === 'popularity') ||
         (!isListDynamic && sortOrder === 'added_time') ||
-        sortOrder === 'default' ||
+        (!_.isUndefined(props.defaultSort) &&
+          sortOrder === props.defaultSort) ||
         sortOrder === undefined
       ),
     ) &&
@@ -335,12 +332,12 @@ export default function ActiveFilters(props: Props) {
             />
           ))
         : null}
-      {showSort ? (
+      {showSort && sortOrder ? (
         <Chip
           key={sortOrder}
           label={`Sort by: ${sortLabels[sortOrder]}`}
           className={classes.chip}
-          onDelete={() => removeFilters({ sort: 'default' })}
+          onDelete={() => removeFilters({ sort: undefined })}
           variant={variant}
         />
       ) : null}

--- a/web/src/components/Filters/SortDropdown.tsx
+++ b/web/src/components/Filters/SortDropdown.tsx
@@ -11,6 +11,7 @@ import {
 import { withRouter } from 'next/router';
 import { WithRouterProps } from 'next/dist/client/with-router';
 import { SortOptions } from '../../types';
+import _ from 'lodash';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -23,7 +24,7 @@ interface OwnProps {
   handleChange: (sortOrder: SortOptions) => void;
   isListDynamic?: boolean;
   validSortOptions?: SortOptions[];
-  selectedSort: SortOptions;
+  selectedSort?: SortOptions;
   showTitle?: boolean;
 }
 
@@ -57,8 +58,8 @@ class SortDropDown extends Component<Props> {
   };
 
   updateURLParam = (param, event) => {
-    const isNewSortDefault = this.isDefaultSort(event.target.value);
-    const isPrevSortDefault = this.isDefaultSort(this.props.selectedSort);
+    const isNewSortDefault = _.isUndefined(event.target.value);
+    const isPrevSortDefault = _.isUndefined(this.props.selectedSort);
     const newSort = isNewSortDefault ? undefined : event.target.value;
 
     if (

--- a/web/src/components/Filters/TypeToggle.tsx
+++ b/web/src/components/Filters/TypeToggle.tsx
@@ -82,7 +82,7 @@ class TypeToggle extends Component<Props> {
         <div className={classes.chipContainer}>
           <Chip
             key={'all'}
-            onClick={() => this.updateTypes('type', [])}
+            onClick={() => this.updateTypes('type', undefined)}
             size="medium"
             color={isTypeAll ? 'primary' : 'secondary'}
             label="All"

--- a/web/src/components/ResponsiveImage.tsx
+++ b/web/src/components/ResponsiveImage.tsx
@@ -14,6 +14,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     height: '100%',
     color: theme.palette.grey[500],
     backgroundColor: theme.palette.grey[300],
+    position: 'absolute',
+    top: 0,
   },
   fallbackImageIcon: {
     alignSelf: 'center',

--- a/web/src/containers/Explore.tsx
+++ b/web/src/containers/Explore.tsx
@@ -124,7 +124,9 @@ class Explore extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
 
-    let defaultFilterParams = DEFAULT_FILTER_PARAMS;
+    let defaultFilterParams: FilterParams = {
+      sortOrder: 'recent',
+    };
 
     if (props.initialType) {
       defaultFilterParams.itemTypes = [props.initialType];
@@ -168,7 +170,7 @@ class Explore extends Component<Props, State> {
         limit: calculateLimit(width, 3, firstRun ? 1 : 0),
         networks,
         genres: genresFilter,
-        sort: sortOrder === 'default' ? 'recent' : sortOrder,
+        sort: _.isUndefined(sortOrder) ? 'recent' : sortOrder,
         releaseYearRange:
           sliders && sliders.releaseYear
             ? {
@@ -336,6 +338,7 @@ class Explore extends Component<Props, State> {
             isListDynamic={false}
             filters={this.state.filters}
             variant="default"
+            defaultSort="recent"
           />
         </div>
         <AllFilters

--- a/web/src/containers/ListDetail.tsx
+++ b/web/src/containers/ListDetail.tsx
@@ -296,8 +296,6 @@ class ListDetail extends Component<Props, State> {
         ? currentFilters.itemTypes
         : initialFilters.itemTypes;
 
-      console.log(currentFilters, initialFilters);
-
       return {
         genres,
         networks,
@@ -325,10 +323,10 @@ class ListDetail extends Component<Props, State> {
         this.state.filters,
         this.state.listFilters,
       ),
-      // sort: sortOrder === 'default' ? undefined : sortOrder,
-      // itemTypes,
-      // genres: genresFilter ? genresFilter : undefined,
-      // networks: networks ? networks : undefined,
+      sort: sortOrder,
+      itemTypes,
+      genres: genresFilter ? genresFilter : undefined,
+      networks: networks ? networks : undefined,
     });
   }
 
@@ -408,15 +406,15 @@ class ListDetail extends Component<Props, State> {
           })
         : undefined;
 
+      let sortOrder = list.configuration.ruleConfiguration.sort?.sort;
+
       return {
         genresFilter: genreRules,
         networks: networkRules,
         itemTypes: itemTypeRules,
         sliders: releaseYearRule,
         people: personRules,
-        sortOrder: list.configuration.ruleConfiguration.sort
-          ? list.configuration.ruleConfiguration.sort.sort
-          : 'default',
+        sortOrder,
       };
     }
   };
@@ -734,7 +732,12 @@ class ListDetail extends Component<Props, State> {
           filters: filterParams,
         },
         () => {
-          updateUrlParamsForFilterRouter(this.props, filterParams);
+          updateUrlParamsForFilterRouter(
+            this.props,
+            filterParams,
+            [],
+            this.state.listFilters,
+          );
           this.retrieveList(false);
         },
       );
@@ -751,7 +754,7 @@ class ListDetail extends Component<Props, State> {
       listId: this.listId,
       bookmark: listBookmark,
       limit: calculateLimit(width, 3),
-      sort: sortOrder === 'default' ? undefined : sortOrder,
+      sort: sortOrder,
       itemTypes,
       genres: genresFilter ? genresFilter : undefined,
       networks: networks ? networks : undefined,

--- a/web/src/containers/PersonDetail.tsx
+++ b/web/src/containers/PersonDetail.tsx
@@ -190,7 +190,9 @@ const styles = (theme: Theme) =>
     },
   });
 
-interface OwnProps {}
+interface OwnProps {
+  preloaded?: boolean;
+}
 
 interface State {
   showFullBiography: boolean;

--- a/web/src/containers/Popular.tsx
+++ b/web/src/containers/Popular.tsx
@@ -145,7 +145,7 @@ class Popular extends Component<Props, State> {
       qs.stringify(props.router.query),
     );
 
-    if (paramsFromQuery.sortOrder === 'default') {
+    if (_.isUndefined(paramsFromQuery.sortOrder)) {
       paramsFromQuery.sortOrder = 'popularity';
     }
 

--- a/web/src/containers/pages/ItemDetailWrapper.tsx
+++ b/web/src/containers/pages/ItemDetailWrapper.tsx
@@ -33,6 +33,7 @@ export default function makeItemDetailWrapper(type: ItemType) {
       ? requestedId[0]
       : requestedId;
 
+    // TODO: Handle not found here...
     const item = useItem(actualId, undefined);
     const releaseDate =
       (item?.release_date && moment(item?.release_date).format('YYYY')) || '';
@@ -92,7 +93,9 @@ export default function makeItemDetailWrapper(type: ItemType) {
           />
         </Head>
         <AppWrapper>
-          <ItemDetail />
+          <ItemDetail
+            itemPreloadedFromServer={props.itemId && !_.isUndefined(item)}
+          />
         </AppWrapper>
       </React.Fragment>
     );
@@ -110,7 +113,6 @@ export default function makeItemDetailWrapper(type: ItemType) {
         await ctx.store.dispatch(itemFetchSuccess(response.data.data));
 
         return {
-          // item: ItemFactory.create(response.data.data),
           itemId: response.data.data.id,
         };
       } else {

--- a/web/src/pages/movies/[id].tsx
+++ b/web/src/pages/movies/[id].tsx
@@ -1,0 +1,3 @@
+import ItemDetailWrapper from '../../containers/pages/ItemDetailWrapper';
+
+export default ItemDetailWrapper('movie');

--- a/web/src/pages/person/[id].tsx
+++ b/web/src/pages/person/[id].tsx
@@ -94,7 +94,7 @@ function PersonDetailWrapper(props: Props) {
         />
       </Head>
       <AppWrapper>
-        <PersonDetail />
+        <PersonDetail preloaded={!_.isUndefined(person)} />
       </AppWrapper>
     </React.Fragment>
   );
@@ -133,7 +133,7 @@ PersonDetailWrapper.getInitialProps = async ctx => {
       ]);
 
       return {
-        person: fullPerson,
+        personId: fullPerson.id,
       };
     } else {
       return {

--- a/web/src/pages/shows/[id].tsx
+++ b/web/src/pages/shows/[id].tsx
@@ -1,0 +1,3 @@
+import ItemDetailWrapper from '../../containers/pages/ItemDetailWrapper';
+
+export default ItemDetailWrapper('show');

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -51,7 +51,7 @@ export class ListFactory {
   }
 }
 
-export type SortOptions = 'popularity' | 'recent' | 'added_time' | 'default';
+export type SortOptions = 'popularity' | 'recent' | 'added_time';
 
 export function isListSortOption(s: string): s is SortOptions {
   const allowed = ['popularity', 'recent', 'added_time', 'default'];

--- a/web/src/types/v2/Item.ts
+++ b/web/src/types/v2/Item.ts
@@ -116,8 +116,8 @@ export class ItemFactory {
       // This will have to change if we ever expand to more regions
       canonicalTitle,
       slug: item.slug,
-      relativeUrl: `/${item.type}/${CANONICAL_ID}`,
-      canonicalUrl: `/${item.type}/[id]?id=${CANONICAL_ID}`,
+      relativeUrl: `/${item.type}s/${CANONICAL_ID}`,
+      canonicalUrl: `/${item.type}s/[id]?id=${CANONICAL_ID}`,
       // description: getDescription(item),
       itemMarkedAsWatched: itemHasTag(item, ActionType.Watched),
 

--- a/web/src/utils/api-client.ts
+++ b/web/src/utils/api-client.ts
@@ -343,11 +343,12 @@ export class TeletrackerApi {
   }
 
   async getPersonCredits(
-    token: String,
+    token: string | undefined,
     id: Id | Slug,
     filterParams?: FilterParams,
     limit?: number,
     bookmark?: string,
+    creditTypes?: string[],
   ) {
     const { itemTypes, networks, sortOrder, genresFilter, sliders } =
       filterParams || {};
@@ -371,6 +372,10 @@ export class TeletrackerApi {
       maxReleaseYear:
         sliders && sliders.releaseYear && sliders.releaseYear.max
           ? sliders.releaseYear.max
+          : undefined,
+      creditTypes:
+        creditTypes && creditTypes.length > 0
+          ? creditTypes.join(',')
           : undefined,
     });
   }

--- a/web/src/utils/changeDetection.ts
+++ b/web/src/utils/changeDetection.ts
@@ -44,12 +44,13 @@ export function filterParamsEqual(
     }
 
     if (left.sortOrder !== right.sortOrder) {
+      console.log(left, right);
       if (
         !defaultSortOrder ||
         (defaultSortOrder &&
-          left.sortOrder === 'default' &&
+          _.isUndefined(left.sortOrder) &&
           right.sortOrder !== defaultSortOrder) ||
-        (left.sortOrder !== defaultSortOrder && right.sortOrder === 'default')
+        (left.sortOrder !== defaultSortOrder && _.isUndefined(right.sortOrder))
       ) {
         return false;
       }

--- a/web/src/utils/saga-client.ts
+++ b/web/src/utils/saga-client.ts
@@ -161,6 +161,7 @@ export class SagaTeletrackerClient {
     filterParams?: FilterParams,
     limit?: number,
     bookmark?: string,
+    creditTypes?: string[],
   ) {
     return yield this.apiCall(
       client => client.getPersonCredits,
@@ -169,6 +170,7 @@ export class SagaTeletrackerClient {
       filterParams,
       limit,
       bookmark,
+      creditTypes,
     );
   }
 

--- a/web/src/utils/searchFilters.ts
+++ b/web/src/utils/searchFilters.ts
@@ -10,19 +10,24 @@ export interface SlidersState {
   releaseYear?: SliderParamState;
 }
 
-export const DEFAULT_FILTER_PARAMS: FilterParams = {
-  sortOrder: 'default',
-};
+export const DEFAULT_FILTER_PARAMS: FilterParams = {};
+
+function removeUndefinedKeys(obj: FilterParams): FilterParams {
+  return _.pickBy(obj, _.negate(_.isUndefined));
+}
 
 export const isDefaultFilter = (filters: FilterParams): boolean => {
-  return _.isEqual(filters, DEFAULT_FILTER_PARAMS);
+  return _.isEqual(
+    removeUndefinedKeys(filters),
+    removeUndefinedKeys(DEFAULT_FILTER_PARAMS),
+  );
 };
 
 export interface FilterParams {
   genresFilter?: number[];
   itemTypes?: ItemType[];
   networks?: NetworkType[];
-  sortOrder: SortOptions;
+  sortOrder?: SortOptions;
   sliders?: SlidersState;
   people?: string[];
 }


### PR DESCRIPTION
1. Removes the 'default' sort option. Default sorts are now represented
as 'undefined'. Pages/the API determine the default sort based on the
context, if a sort is not defined. This fixes an issue with duplicate
cast items loading on the PDP.

2. Fix issue on ListDetail where changing the filters reloaded the
entire page

3. Begin migrating ItemDetail page urls to be more RESTful: /movies/{id}
and /shows/{id} rather than their singular equivalents.

4. Fix issue where item on ItemDetail was loaded from server twice when
initially loaded via SSR.

5. Fix issue with missing poster image styling.

6. Only return cast memberships when requesting credits on PDP rather
than cast and crew.

7. Fix issue on login redirect state that wouldn't take you to Popular page if you started the login flow on /login
