### PR TITLE
Use the itemId to seed the ItemCard

### DIFF
--- a/web/src/components/PersonDetail/PersonCredits.tsx
+++ b/web/src/components/PersonDetail/PersonCredits.tsx
@@ -28,7 +28,7 @@ import { selectPerson } from './hooks';
 import { Item } from '../../types/v2/Item';
 import { collect } from '../../utils/collection-utils';
 import { useWithUserContext } from '../../hooks/useWithUser';
-import dequal from 'dequal';
+import { hookDeepEqual } from '../../hooks/util';
 
 const selectCreditDetails = createSelector(
   selectPerson,
@@ -95,7 +95,7 @@ export default function PersonCredits(props: Props) {
   );
   const itemById = useStateSelector(
     state => state.itemDetail.thingsById,
-    dequal,
+    hookDeepEqual,
   );
 
   let dispatchCreditsFetch = useDispatchAction(personCreditsFetchInitiated);
@@ -227,7 +227,7 @@ export default function PersonCredits(props: Props) {
           <Grid container spacing={2}>
             {filmography.map(item =>
               item && item.posterImage ? (
-                <ItemCard key={item.id} userSelf={userSelf} item={item} />
+                <ItemCard key={item.id} userSelf={userSelf} itemId={item.id} />
               ) : null,
             )}
           </Grid>

--- a/web/src/components/Recommendations.tsx
+++ b/web/src/components/Recommendations.tsx
@@ -51,7 +51,9 @@ function Recommendations(props: Props) {
         </Typography>
         <Grid container spacing={2} className={classes.grid}>
           {recommendations.slice(0, limit).map(item => {
-            return <ItemCard key={item.id} userSelf={userSelf} item={item} />;
+            return (
+              <ItemCard key={item.id} userSelf={userSelf} itemId={item.id} />
+            );
           })}
         </Grid>
       </React.Fragment>

--- a/web/src/containers/Explore.tsx
+++ b/web/src/containers/Explore.tsx
@@ -43,8 +43,8 @@ import {
   useDispatchAction,
   useDispatchSideEffect,
 } from '../hooks/useDispatchAction';
-import dequal from 'dequal';
 import { useGenres, useNetworks } from '../hooks/useStateMetadata';
+import { hookDeepEqual } from '../hooks/util';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -129,7 +129,7 @@ function Explore(props: Props) {
   const thingsById = useStateSelector(state => state.itemDetail.thingsById);
   const [popular, previousPopular] = useStateSelectorWithPrevious(
     state => state.popular.popular,
-    dequal,
+    hookDeepEqual,
   );
   const popularBookmark = useStateSelector(
     state => state.popular.popularBookmark,
@@ -451,7 +451,7 @@ function Explore(props: Props) {
                     <ItemCard
                       key={result}
                       userSelf={userState.userSelf}
-                      item={thing}
+                      itemId={thing.id}
                       hasLoaded={setVisibleItems}
                     />
                   );

--- a/web/src/containers/New.tsx
+++ b/web/src/containers/New.tsx
@@ -141,7 +141,7 @@ class New extends Component<Props> {
             return (
               <ItemCard
                 key={thing.id}
-                item={thing}
+                itemId={thing.id}
                 userSelf={this.props.userSelf!}
               />
             );

--- a/web/src/containers/Search.tsx
+++ b/web/src/containers/Search.tsx
@@ -352,7 +352,7 @@ const Search = ({ inViewportChange }) => {
                           <ItemCard
                             key={result.id}
                             userSelf={withUserState.userSelf}
-                            item={result}
+                            itemId={result.id}
                             hasLoaded={loadHandler}
                           />
                         );

--- a/web/src/reducers/item-detail.ts
+++ b/web/src/reducers/item-detail.ts
@@ -107,7 +107,7 @@ const itemFetchSuccess = handleAction(
     }
 
     // TODO: Truncate thingsById after a certain point
-    return {
+    let newState = {
       ...state,
       fetching: false,
       itemDetail: newThing.id,
@@ -116,10 +116,16 @@ const itemFetchSuccess = handleAction(
         [payload!.id]: newThing,
       } as ThingMap,
     } as State;
+
+    return updateStateWithNewThings(newState, newThing.recommendations || []);
   },
 );
 
 const updateStateWithNewThings = (existingState: State, newThings: Item[]) => {
+  if (newThings.length === 0) {
+    return existingState;
+  }
+
   let thingsById = existingState.thingsById || {};
   let newThingsMerged = newThings.map(curr => {
     let existingThing: Item | undefined = thingsById[curr.id];

--- a/web/src/types/v2/Item.ts
+++ b/web/src/types/v2/Item.ts
@@ -33,7 +33,7 @@ export interface Item extends HasSlug {
   crew?: ItemCrewMember[];
   external_ids?: ItemExternalId[];
   genres?: ItemGenre[];
-  id: string;
+  id: Id;
   images?: ItemImage[];
   original_title: string;
   overview?: string;


### PR DESCRIPTION
This change allows any updates to individual items to appear instantly
on its respective ItemCard, regardless of the current container.