### PR TITLE
re-design availability

### DIFF
--- a/web/src/components/Availability.tsx
+++ b/web/src/components/Availability.tsx
@@ -24,7 +24,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     },
   },
   availabilityWrapper: {
-    maxWidth: 500,
     width: '100%',
   },
   availabilePlatforms: {
@@ -176,25 +175,30 @@ const Availability = (props: Props) => {
             return;
           }
 
-          const getCleanOfferTitle = (offerType: string) => {
-            if (offerType === 'subscription') {
-              return 'Stream on';
-            } else if (offerType === 'buy') {
-              return 'Buy on';
-            } else if (offerType === 'rent') {
-              return 'Rent on';
-            } else if (offerType === 'theater') {
-              return 'In theaters now! Get tickets on';
-            } else if (offerType === 'free') {
-              return 'Free on';
-            } else if (offerType === 'aggregate') {
-              return 'Watch all seasons on';
-            } else {
-              return 'Watch on ';
-            }
-          };
+          let cleanOfferTitle: string;
+          switch (offerType) {
+            case OfferType.subscription:
+              cleanOfferTitle = 'Stream on';
+              break;
+            case OfferType.buy:
+              cleanOfferTitle = 'Buy on';
+              break;
+            case OfferType.rent:
+              cleanOfferTitle = 'Rent on';
+              break;
+            case OfferType.theater:
+              cleanOfferTitle = 'In theaters now! Get tickets on';
+              break;
+            case OfferType.free:
+              cleanOfferTitle = 'Free on';
+              break;
+            case OfferType.aggregate:
+              cleanOfferTitle = 'Watch all seasons on';
+              break;
+            default:
+              cleanOfferTitle = 'Watch all seasons on';
+          }
 
-          const cleanOfferTitle = getCleanOfferTitle(offerType);
           const link = getDeepLink(availability);
 
           return (


### PR DESCRIPTION
cleaned up some of the availability stying for desktop & mobile.  It's in a pretty good place right now.

- offerTypes of the same type show up in a row that wraps
- unavailable now also gets similar styling to match
- removed tabs
- mobile fills full width for each available offer
- cleaned up css and some redundant html


mobile:
![image](https://user-images.githubusercontent.com/6005331/81463264-3fc8f080-9186-11ea-8736-3afe7a30440b.png)

Desktop:
![image](https://user-images.githubusercontent.com/6005331/81463268-4b1c1c00-9186-11ea-9404-84af72330fda.png)
