### PR TITLE
small tweak to get logos looking better

### DIFF
--- a/web/src/components/Availability.tsx
+++ b/web/src/components/Availability.tsx
@@ -93,7 +93,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   networkLogo: {
     width: 60,
     borderRadius: 4,
-    backgroundSize: '80%',
+    backgroundSize: '70%',
   },
   platform: {
     display: 'flex',


### PR DESCRIPTION
Small tweak that gets Apple svg looking better without hurting the other logos from what I can tell.  If we notice any issues I can adjust the svg itself to have a little more spacing in it.
Fixes: https://github.com/chrisbenincasa/teletracker/issues/781