### PR TITLE
focus search on mobile

### DIFF
--- a/web/src/components/Toolbar/Search.tsx
+++ b/web/src/components/Toolbar/Search.tsx
@@ -70,6 +70,7 @@ interface Props {
   readonly onDrawerChange?: (close?: boolean) => void;
   readonly inputStyle?: object;
   readonly filters?: FilterParams;
+  readonly forceFocus?: boolean;
   readonly quickSearchColor?: string;
   readonly quickSearchEnabled?: boolean;
 }
@@ -242,6 +243,7 @@ function Search(props: Props) {
         onChange={handleSearchChange}
         onKeyDown={handleSearchForEnter}
         onFocus={handleSearchFocus}
+        autoFocus={props.forceFocus}
         style={props.inputStyle || undefined}
       />
       {searchText.length > 0 ||

--- a/web/src/components/Toolbar/Toolbar.tsx
+++ b/web/src/components/Toolbar/Toolbar.tsx
@@ -287,7 +287,7 @@ export default function Toolbar(props: Props) {
         direction="down"
         in={mobileSearchBarOpen}
         timeout={100}
-        mountOnEnter
+        unmountOnExit
       >
         <div
           className={clsx(classes.sectionMobile, classes.mobileSearchContainer)}
@@ -297,6 +297,7 @@ export default function Toolbar(props: Props) {
               drawerOpen={drawerOpen}
               onDrawerChange={fireOnDrawerChange}
               quickSearchEnabled={showQuickSearch}
+              forceFocus={true}
             />
           </div>
           <IconButton


### PR DESCRIPTION
This forces the mobile search input to have focus anytime it is rendered.  This should allow mobile devices to automatically open the keyboard once you click the search icon