### PR TITLE
hide public option for lists

### DIFF
--- a/web/src/containers/ListDetail.tsx
+++ b/web/src/containers/ListDetail.tsx
@@ -391,12 +391,12 @@ function ListDetail(props: ListDetailProps) {
               label="Automatically remove items after watching"
             />
           </MenuItem>
-          <MenuItem onClick={() => setPublicListOptionsOpen(true)}>
+          {/* <MenuItem onClick={() => setPublicListOptionsOpen(true)}>
             <ListItemIcon>
               <Public />
             </ListItemIcon>
             {`Make list ${list.isPublic ? 'Private' : 'Public'}`}
-          </MenuItem>
+          </MenuItem> */}
         </Menu>
       </div>
     );


### PR DESCRIPTION
- This hides the option to make a list public since this isn't currently supported on the backed.