### PR TITLE
Fix featured items

### DIFF
--- a/web/src/components/Featured.tsx
+++ b/web/src/components/Featured.tsx
@@ -23,7 +23,6 @@ import { Id } from '../types/v2';
 import useStateSelector from '../hooks/useStateSelector';
 import selectItems from '../selectors/selectItems';
 import useIsMobile from '../hooks/useIsMobile';
-import { usePrevious } from '../hooks/usePrevious';
 
 const useStyles = makeStyles((theme: Theme) => ({
   backdropContainer: {

--- a/web/src/containers/Explore.tsx
+++ b/web/src/containers/Explore.tsx
@@ -204,15 +204,8 @@ function Explore() {
 
     // If we don't have enough content to fill featured items, don't show any
     if (featuredItems.length < numberFeaturedItems) {
-      console.log(featuredItems.length < numberFeaturedItems);
-      console.log(popular!.length < featuredRequiredItems);
-      console.log(popular!.length);
-
-      console.log(featuredRequiredItems);
-
       // Prevent re-setting state if it's already been reset
       if (featuredItemsIndex.length > 0) {
-        console.log('resest');
         setFeaturedItemsIndex([]);
         setFeaturedItems([]);
         setNeedsNewFeatured(false);
@@ -234,7 +227,7 @@ function Explore() {
     if (popular?.length === DEFAULT_POPULAR_LIMIT && missingItems > 0) {
       loadPopular(true, missingItems);
     }
-  }, [popular, thingsById, isMobile, theme, featuredItemsIndex]);
+  }, [popular, thingsById, width, theme, featuredItemsIndex]);
 
   const toggleFilters = () => {
     setShowFilter(prev => !prev);
@@ -293,7 +286,7 @@ function Explore() {
     if (isInitialFetch || isNewFetch || didScreenResize || didNavigate) {
       updateFeaturedItems();
     }
-  }, [popular, loading, width, isMobile, needsNewFeatured]);
+  }, [popular, loading, width, needsNewFeatured]);
 
   //
   // Render functions
@@ -379,7 +372,7 @@ function Explore() {
       </div>
     ) : null;
   };
-  console.log({ featuredItems });
+
   return (
     <ScrollToTopContainer>
       <div className={classes.popularWrapper}>


### PR DESCRIPTION
Fixes: #778
Also fixes issue where Featured item remained hidden after re-size
Also Also fixes issue where Featured items were accidentally reset if you went from mobile => desktop because the popular limit threshold was never met.  I removed this entirely because we now show the Featured items inline as well.  Originally this was intended to prevent situations where we only had 2 featured items and nothing under it.  Now that is impossible, though it still makes for a weird display, something to consider for the future